### PR TITLE
Modular `OutputBuilder` + better demo performance

### DIFF
--- a/src/diart/demo.py
+++ b/src/diart/demo.py
@@ -57,7 +57,12 @@ else:
 # Build pipeline from audio source and stream predictions to a real-time plot
 pipeline.from_source(audio_source).pipe(
     ops.do(RTTMWriter(path=output_dir / "output.rttm")),
-    dops.accumulate_output(pipeline.duration, pipeline.step),
+    dops.buffer_output(
+        duration=pipeline.duration,
+        step=pipeline.step,
+        latency=pipeline.latency,
+        sample_rate=audio_source.sample_rate
+    ),
 ).subscribe(RealTimePlot(pipeline.duration, pipeline.latency))
 
 # Read audio source as a stream

--- a/src/diart/demo.py
+++ b/src/diart/demo.py
@@ -46,7 +46,6 @@ if args.source != "microphone":
     audio_source = src.FileAudioSource(
         file=args.source,
         uri=uri,
-        sample_rate=args.sample_rate,
         reader=src.RegularAudioFileReader(
             args.sample_rate, pipeline.duration, pipeline.step
         ),

--- a/src/diart/demo.py
+++ b/src/diart/demo.py
@@ -1,10 +1,11 @@
-from pathlib import Path
 import argparse
+from pathlib import Path
 
+import diart.operators as dops
 import diart.sources as src
+import rx.operators as ops
 from diart.pipelines import OnlineSpeakerDiarization
-from diart.sinks import OutputBuilder
-
+from diart.sinks import RealTimePlot, RTTMWriter
 
 # Define script arguments
 parser = argparse.ArgumentParser()
@@ -38,7 +39,6 @@ pipeline = OnlineSpeakerDiarization(
 )
 
 # Manage audio source
-uri = args.source
 if args.source != "microphone":
     args.source = Path(args.source).expanduser()
     uri = args.source.name.split(".")[0]
@@ -49,23 +49,18 @@ if args.source != "microphone":
         uri=uri,
         sample_rate=args.sample_rate,
         window_duration=pipeline.duration,
-        step=args.step,
+        step=pipeline.step,
     )
 else:
     output_dir = Path("~/").expanduser() if args.output is None else Path(args.output)
     audio_source = src.MicrophoneAudioSource(args.sample_rate)
 
-# Configure output builder to write an RTTM file and to draw in real time
-output_builder = OutputBuilder(
-    duration=pipeline.duration,
-    step=args.step,
-    latency=args.latency,
-    output_path=output_dir / "output.rttm",
-    visualization="slide",
-    # reference=output_dir / f"{uri}.rttm",
-)
-# Build pipeline from audio source and stream results to the output builder
-pipeline.from_source(audio_source, output_waveform=True).subscribe(output_builder)
+# Build pipeline from audio source and stream predictions to a real-time plot
+pipeline.from_source(audio_source).pipe(
+    ops.do(RTTMWriter(path=output_dir / "output.rttm")),
+    dops.accumulate_output(pipeline.duration, pipeline.step),
+).subscribe(RealTimePlot(pipeline.duration, pipeline.latency))
+
 # Read audio source as a stream
 if args.source == "microphone":
     print("Recording...")

--- a/src/diart/operators.py
+++ b/src/diart/operators.py
@@ -176,9 +176,33 @@ def buffer_output(
     step: float,
     latency: float,
     sample_rate: int,
-    merge_collar: float = 0.05,
+    patch_collar: float = 0.05,
 ) -> Operator:
+    """Store last predictions and audio inside a fixed buffer.
+    Provides the best time/space complexity trade-off if the past data is not needed.
+
+    Parameters
+    ----------
+    duration: float
+        Buffer duration in seconds.
+    step: float
+        Duration of the chunks at each event in seconds.
+        The first chunk may be bigger given the latency.
+    latency: float
+        Latency of the system in seconds.
+    sample_rate: int
+        Sample rate of the audio source.
+    patch_collar: float, optional
+        Collar to merge speaker turns of the same speaker, in seconds.
+        Defaults to 0.05 (i.e. 50ms)
+
+    Returns
+    -------
+    A reactive x operator implementing this behavior.
+    """
+    # Define some useful constants
     num_samples = int(round(duration * sample_rate))
+    num_step_samples = int(round(step * sample_rate))
     resolution = 1 / sample_rate
 
     def accumulate(
@@ -187,30 +211,42 @@ def buffer_output(
     ) -> OutputAccumulationState:
         value = PredictionWithAudio(*value)
         annotation, waveform = None, None
+
+        # Determine the real time of the stream and the start time of the buffer
         real_time = duration if state.annotation is None else state.real_time + step
         start_time = max(0., real_time - latency - duration)
 
+        # Update annotation and constrain its bounds to the buffer
         if state.annotation is None:
             annotation = value.prediction
         else:
             annotation = state.annotation.update(value.prediction) \
-                .support(merge_collar) \
+                .support(patch_collar) \
                 .extrude(Segment(0, start_time))
 
-        new_next_sample = 0
+        # Update the audio buffer if there's audio in the input
+        new_next_sample = state.next_sample + num_step_samples
         if value.has_audio:
-            num_new_samples = value.waveform.data.shape[0]
-            new_next_sample = state.next_sample + num_new_samples
             if state.waveform is None:
-                waveform = np.zeros((num_samples + num_new_samples, 1))
-                waveform[:num_new_samples] = value.waveform.data
+                # Determine the size of the first chunk
+                expected_duration = duration + step - latency
+                expected_samples = int(round(expected_duration * sample_rate))
+                # Shift indicator to start copying new audio in the buffer
+                new_next_sample = state.next_sample + expected_samples
+                # Buffer size is duration + step
+                waveform = np.zeros((num_samples + num_step_samples, 1))
+                # Copy first chunk into buffer (slicing because of rounding errors)
+                waveform[:expected_samples] = value.waveform.data[:expected_samples]
             elif state.next_sample <= num_samples:
+                # The buffer isn't full, copy into next free buffer chunk
                 waveform = state.waveform.data
                 waveform[state.next_sample:new_next_sample] = value.waveform.data
             else:
-                waveform = np.roll(state.waveform.data, -num_new_samples, axis=0)
-                waveform[-num_new_samples:] = value.waveform.data
+                # The buffer is full, shift values to the left and copy into last buffer chunk
+                waveform = np.roll(state.waveform.data, -num_step_samples, axis=0)
+                waveform[-num_step_samples:] = value.waveform.data
 
+            # Wrap waveform in a sliding window feature to include timestamps
             window = SlidingWindow(start=start_time, duration=resolution, step=resolution)
             waveform = SlidingWindowFeature(waveform, window)
 

--- a/src/diart/pipelines.py
+++ b/src/diart/pipelines.py
@@ -41,12 +41,18 @@ class OnlineSpeakerDiarization:
         self.beta = beta
         self.max_speakers = max_speakers
 
+    @property
+    def sample_rate(self) -> int:
+        return self.segmentation.model.audio.sample_rate
+
     def get_end_time(self, source: src.AudioSource) -> Optional[float]:
         if source.duration is not None:
             return source.duration - source.duration % self.step
         return None
 
     def from_source(self, source: src.AudioSource, output_waveform: bool = True) -> rx.Observable:
+        msg = f"Audio source has sample rate {source.sample_rate}, expected {self.sample_rate}"
+        assert source.sample_rate == self.sample_rate, msg
         # Regularize the stream to a specific chunk duration and step
         regular_stream = source.stream
         if not source.is_regular:

--- a/src/diart/pipelines.py
+++ b/src/diart/pipelines.py
@@ -3,8 +3,8 @@ import rx.operators as ops
 from typing import Optional
 from pyannote.audio.pipelines.utils import PipelineModel
 
-from .sources import AudioSource
-from . import operators as my_ops
+from . import sources as src
+from . import operators as dops
 from . import functional as fn
 
 
@@ -40,17 +40,17 @@ class OnlineSpeakerDiarization:
         self.beta = beta
         self.max_speakers = max_speakers
 
-    def get_end_time(self, source: AudioSource) -> Optional[float]:
+    def get_end_time(self, source: src.AudioSource) -> Optional[float]:
         if source.duration is not None:
             return source.duration - source.duration % self.step
         return None
 
-    def from_source(self, source: AudioSource, output_waveform: bool = False) -> rx.Observable:
+    def from_source(self, source: src.AudioSource, output_waveform: bool = True) -> rx.Observable:
         # Regularize the stream to a specific chunk duration and step
         regular_stream = source.stream
         if not source.is_regular:
             regular_stream = source.stream.pipe(
-                my_ops.regularize_stream(self.duration, self.step, source.sample_rate)
+                dops.regularize_stream(self.duration, self.step, source.sample_rate)
             )
         # Branch the stream to calculate chunk segmentation
         segmentation_stream = regular_stream.pipe(
@@ -75,20 +75,21 @@ class OnlineSpeakerDiarization:
         pipeline = rx.zip(segmentation_stream, embedding_stream).pipe(
             ops.starmap(clustering),
             # Buffer 'num_overlapping' sliding chunks with a step of 1 chunk
-            my_ops.buffer_slide(aggregation.num_overlapping_windows),
+            dops.buffer_slide(aggregation.num_overlapping_windows),
             # Aggregate overlapping output windows
             ops.map(aggregation),
             # Binarize output
             ops.map(fn.Binarize(source.uri, self.tau_active)),
         )
+        # Add corresponding waveform to the output
         if output_waveform:
             window_selector = fn.DelayedAggregation(
                 self.step, self.latency, strategy="first", stream_end=end_time
             )
-            pipeline = pipeline.pipe(
-                ops.zip(regular_stream.pipe(
-                    my_ops.buffer_slide(window_selector.num_overlapping_windows),
-                    ops.map(window_selector),
-                ))
+            waveform_stream = regular_stream.pipe(
+                dops.buffer_slide(window_selector.num_overlapping_windows),
+                ops.map(window_selector),
             )
-        return pipeline
+            return rx.zip(pipeline, waveform_stream)
+        # No waveform needed, add None for consistency
+        return pipeline.pipe(ops.map(lambda ann: (ann, None)))

--- a/src/diart/sources.py
+++ b/src/diart/sources.py
@@ -24,7 +24,6 @@ class AudioSource:
         self.uri = uri
         self.sample_rate = sample_rate
         self.stream = Subject()
-        self.resolution = 1 / sample_rate
 
     @property
     def is_regular(self) -> bool:
@@ -163,8 +162,6 @@ class FileAudioSource(AudioSource):
         The file to stream.
     uri: Text
         Unique identifier of the audio source.
-    sample_rate: int
-        Sample rate of the audio source.
     reader: AudioFileReader
         Determines how the file will be read.
     """
@@ -172,10 +169,9 @@ class FileAudioSource(AudioSource):
         self,
         file: AudioFile,
         uri: Text,
-        sample_rate: int,
         reader: AudioFileReader
     ):
-        super().__init__(uri, sample_rate)
+        super().__init__(uri, reader.sample_rate)
         self.reader = reader
         self._duration = self.reader.get_duration(file)
         self.file = file


### PR DESCRIPTION
## Changelog

- Add `RTTMWriter` observer to write system outputs
- Add `accumulate_output()` and `buffer_output()` operators to concatenate system outputs either by accumulating all past predictions or by keeping only the last ones
- Add `RealTimePlot` observer to draw system outputs in real time
- `OnlineSpeakerDiarization` pipeline yields `None` waveform if `output_waveform=False` for consistency
- Remove redundant sample rate parameter in `FileAudioSource`
- Make `accumulate_output()` more efficient by pre-allocating the audio buffer and hence reducing the number of costly concatenate operations
