### PR TITLE
Add `RealTimeInference` and `Benchmark`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ scipy>=1.6.0
 sounddevice>=0.4.2
 einops>=0.3.0
 tqdm>=4.64.0
+pandas>=1.4.2
 git+https://github.com/pyannote/pyannote-audio.git@develop#egg=pyannote-audio

--- a/src/diart/benchmark.py
+++ b/src/diart/benchmark.py
@@ -1,90 +1,114 @@
-import argparse
 from pathlib import Path
+from typing import Union, Text, Optional
 
-import torch
+import pandas as pd
 from pyannote.database.util import load_rttm
 from pyannote.metrics.diarization import DiarizationErrorRate
 
-import diart.argdoc as argdoc
 import diart.operators as dops
 import diart.sources as src
-from diart.pipelines import OnlineSpeakerDiarization, PipelineConfig
+from diart.pipelines import OnlineSpeakerDiarization
 from diart.sinks import RTTMWriter
 
-# Define script arguments
-parser = argparse.ArgumentParser()
-parser.add_argument("root", type=str, help="Directory with audio files CONVERSATION.(wav|flac|m4a|...)")
-parser.add_argument("--reference", type=str, help="Optional. Directory with RTTM files CONVERSATION.rttm. Names must match audio files")
-parser.add_argument("--step", default=0.5, type=float, help=f"{argdoc.STEP}. Defaults to 0.5")
-parser.add_argument("--latency", default=0.5, type=float, help=f"{argdoc.LATENCY}. Defaults to 0.5")
-parser.add_argument("--tau", default=0.5, type=float, help=f"{argdoc.TAU}. Defaults to 0.5")
-parser.add_argument("--rho", default=0.3, type=float, help=f"{argdoc.RHO}. Defaults to 0.3")
-parser.add_argument("--delta", default=1, type=float, help=f"{argdoc.DELTA}. Defaults to 1")
-parser.add_argument("--gamma", default=3, type=float, help=f"{argdoc.GAMMA}. Defaults to 3")
-parser.add_argument("--beta", default=10, type=float, help=f"{argdoc.BETA}. Defaults to 10")
-parser.add_argument("--max-speakers", default=20, type=int, help=f"{argdoc.MAX_SPEAKERS}. Defaults to 20")
-parser.add_argument("--batch-size", default=32, type=int, help="For segmentation and embedding pre-calculation. If BATCH_SIZE < 2, run fully online and estimate real-time latency. Defaults to 32")
-parser.add_argument("--gpu", dest="gpu", action="store_true", help=argdoc.GPU)
-parser.add_argument("--output", type=str, help=f"{argdoc.OUTPUT}. Defaults to `root`")
-args = parser.parse_args()
 
-args.root = Path(args.root)
-assert args.root.is_dir(), "Root argument must be a directory"
-if args.reference is not None:
-    args.reference = Path(args.reference)
-    assert args.reference.is_dir(), "Reference argument must be a directory"
-args.output = args.root if args.output is None else Path(args.output)
-args.output.mkdir(parents=True, exist_ok=True)
+class Benchmark:
+    def __init__(
+        self,
+        speech_path: Union[Text, Path],
+        reference_path: Optional[Union[Text, Path]] = None,
+        output_path: Optional[Union[Text, Path]] = None,
+    ):
+        self.speech_path = Path(speech_path).expanduser()
+        assert self.speech_path.is_dir(), "Speech path must be a directory"
 
-# Define online speaker diarization pipeline
-config = PipelineConfig(
-    step=args.step,
-    latency=args.latency,
-    tau_active=args.tau,
-    rho_update=args.rho,
-    delta_new=args.delta,
-    gamma=args.gamma,
-    beta=args.beta,
-    max_speakers=args.max_speakers,
-    device=torch.device("cuda") if args.gpu else None,
-)
-pipeline = OnlineSpeakerDiarization(config)
+        self.reference_path = reference_path
+        if reference_path is not None:
+            self.reference_path = Path(self.reference_path).expanduser()
+            assert self.reference_path.is_dir(), "Reference path must be a directory"
 
-# Run inference
-chunk_loader = src.ChunkLoader(pipeline.sample_rate, pipeline.duration, config.step)
-for filepath in args.root.expanduser().iterdir():
-    num_chunks = chunk_loader.num_chunks(filepath)
+        if output_path is None:
+            self.output_path = self.speech_path
+        else:
+            self.output_path = Path(output_path).expanduser()
+            self.output_path.mkdir(parents=True, exist_ok=True)
 
-    # Stream fully online if batch size is 1 or lower
-    source = None
-    if args.batch_size < 2:
-        source = src.FileAudioSource(
-            filepath,
-            filepath.stem,
-            src.RegularAudioFileReader(pipeline.sample_rate, pipeline.duration, config.step),
-            # Benchmark the processing time of a single chunk
-            profile=True,
-        )
-        observable = pipeline.from_source(source, output_waveform=False)
-    else:
-        observable = pipeline.from_file(filepath, batch_size=args.batch_size, verbose=True)
+    def __call__(self, pipeline: OnlineSpeakerDiarization, batch_size: int = 32) -> Optional[pd.DataFrame]:
+        # Run inference
+        chunk_loader = src.ChunkLoader(pipeline.sample_rate, pipeline.duration, pipeline.config.step)
+        for filepath in self.speech_path.iterdir():
+            num_chunks = chunk_loader.num_chunks(filepath)
 
-    observable.pipe(
-        dops.progress(f"Streaming {filepath.stem}", total=num_chunks, leave=source is None)
-    ).subscribe(
-        RTTMWriter(path=args.output / f"{filepath.stem}.rttm")
-    )
+            # Stream fully online if batch size is 1 or lower
+            source = None
+            if batch_size < 2:
+                source = src.FileAudioSource(
+                    filepath,
+                    filepath.stem,
+                    src.RegularAudioFileReader(pipeline.sample_rate, pipeline.duration, pipeline.config.step),
+                    # Benchmark the processing time of a single chunk
+                    profile=True,
+                )
+                observable = pipeline.from_source(source, output_waveform=False)
+            else:
+                observable = pipeline.from_file(filepath, batch_size=batch_size, verbose=True)
 
-    if source is not None:
-        source.read()
+            observable.pipe(
+                dops.progress(f"Streaming {filepath.stem}", total=num_chunks, leave=source is None)
+            ).subscribe(
+                RTTMWriter(path=self.output_path / f"{filepath.stem}.rttm")
+            )
 
-# Run evaluation
-if args.reference is not None:
-    metric = DiarizationErrorRate(collar=0, skip_overlap=False)
-    for ref_path in args.reference.iterdir():
-        ref = load_rttm(ref_path).popitem()[1]
-        hyp = load_rttm(args.output / ref_path.name).popitem()[1]
-        metric(ref, hyp)
-    print()
-    metric.report(display=True)
-    print()
+            if source is not None:
+                source.read()
+
+        # Run evaluation
+        if self.reference_path is not None:
+            metric = DiarizationErrorRate(collar=0, skip_overlap=False)
+            for ref_path in self.reference_path.iterdir():
+                ref = load_rttm(ref_path).popitem()[1]
+                hyp = load_rttm(self.output_path / ref_path.name).popitem()[1]
+                metric(ref, hyp)
+
+            return metric.report(display=True)
+
+
+if __name__ == "__main__":
+    import argparse
+    import torch
+    import diart.argdoc as argdoc
+    from diart.pipelines import PipelineConfig
+
+    # Define script arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("root", type=str, help="Directory with audio files CONVERSATION.(wav|flac|m4a|...)")
+    parser.add_argument("--reference", type=str, help="Optional. Directory with RTTM files CONVERSATION.rttm. Names must match audio files")
+    parser.add_argument("--step", default=0.5, type=float, help=f"{argdoc.STEP}. Defaults to 0.5")
+    parser.add_argument("--latency", default=0.5, type=float, help=f"{argdoc.LATENCY}. Defaults to 0.5")
+    parser.add_argument("--tau", default=0.5, type=float, help=f"{argdoc.TAU}. Defaults to 0.5")
+    parser.add_argument("--rho", default=0.3, type=float, help=f"{argdoc.RHO}. Defaults to 0.3")
+    parser.add_argument("--delta", default=1, type=float, help=f"{argdoc.DELTA}. Defaults to 1")
+    parser.add_argument("--gamma", default=3, type=float, help=f"{argdoc.GAMMA}. Defaults to 3")
+    parser.add_argument("--beta", default=10, type=float, help=f"{argdoc.BETA}. Defaults to 10")
+    parser.add_argument("--max-speakers", default=20, type=int, help=f"{argdoc.MAX_SPEAKERS}. Defaults to 20")
+    parser.add_argument("--batch-size", default=32, type=int, help="For segmentation and embedding pre-calculation. If BATCH_SIZE < 2, run fully online and estimate real-time latency. Defaults to 32")
+    parser.add_argument("--gpu", dest="gpu", action="store_true", help=argdoc.GPU)
+    parser.add_argument("--output", type=str, help=f"{argdoc.OUTPUT}. Defaults to `root`")
+    args = parser.parse_args()
+
+    # Set benchmark configuration
+    benchmark = Benchmark(args.root, args.reference, args.output)
+
+    # Define online speaker diarization pipeline
+    pipeline = OnlineSpeakerDiarization(PipelineConfig(
+        step=args.step,
+        latency=args.latency,
+        tau_active=args.tau,
+        rho_update=args.rho,
+        delta_new=args.delta,
+        gamma=args.gamma,
+        beta=args.beta,
+        max_speakers=args.max_speakers,
+        device=torch.device("cuda") if args.gpu else None,
+    ))
+
+    benchmark(pipeline, args.batch_size)

--- a/src/diart/benchmark.py
+++ b/src/diart/benchmark.py
@@ -1,83 +1,12 @@
-from pathlib import Path
-from typing import Union, Text, Optional
+import argparse
 
-import pandas as pd
-from pyannote.database.util import load_rttm
-from pyannote.metrics.diarization import DiarizationErrorRate
+import torch
 
-import diart.operators as dops
-import diart.sources as src
-from diart.pipelines import OnlineSpeakerDiarization
-from diart.sinks import RTTMWriter
-
-
-class Benchmark:
-    def __init__(
-        self,
-        speech_path: Union[Text, Path],
-        reference_path: Optional[Union[Text, Path]] = None,
-        output_path: Optional[Union[Text, Path]] = None,
-    ):
-        self.speech_path = Path(speech_path).expanduser()
-        assert self.speech_path.is_dir(), "Speech path must be a directory"
-
-        self.reference_path = reference_path
-        if reference_path is not None:
-            self.reference_path = Path(self.reference_path).expanduser()
-            assert self.reference_path.is_dir(), "Reference path must be a directory"
-
-        if output_path is None:
-            self.output_path = self.speech_path
-        else:
-            self.output_path = Path(output_path).expanduser()
-            self.output_path.mkdir(parents=True, exist_ok=True)
-
-    def __call__(self, pipeline: OnlineSpeakerDiarization, batch_size: int = 32) -> Optional[pd.DataFrame]:
-        # Run inference
-        chunk_loader = src.ChunkLoader(pipeline.sample_rate, pipeline.duration, pipeline.config.step)
-        for filepath in self.speech_path.iterdir():
-            num_chunks = chunk_loader.num_chunks(filepath)
-
-            # Stream fully online if batch size is 1 or lower
-            source = None
-            if batch_size < 2:
-                source = src.FileAudioSource(
-                    filepath,
-                    filepath.stem,
-                    src.RegularAudioFileReader(pipeline.sample_rate, pipeline.duration, pipeline.config.step),
-                    # Benchmark the processing time of a single chunk
-                    profile=True,
-                )
-                observable = pipeline.from_source(source, output_waveform=False)
-            else:
-                observable = pipeline.from_file(filepath, batch_size=batch_size, verbose=True)
-
-            observable.pipe(
-                dops.progress(f"Streaming {filepath.stem}", total=num_chunks, leave=source is None)
-            ).subscribe(
-                RTTMWriter(path=self.output_path / f"{filepath.stem}.rttm")
-            )
-
-            if source is not None:
-                source.read()
-
-        # Run evaluation
-        if self.reference_path is not None:
-            metric = DiarizationErrorRate(collar=0, skip_overlap=False)
-            for ref_path in self.reference_path.iterdir():
-                ref = load_rttm(ref_path).popitem()[1]
-                hyp = load_rttm(self.output_path / ref_path.name).popitem()[1]
-                metric(ref, hyp)
-
-            return metric.report(display=True)
-
+import diart.argdoc as argdoc
+from diart.inference import Benchmark
+from diart.pipelines import OnlineSpeakerDiarization, PipelineConfig
 
 if __name__ == "__main__":
-    import argparse
-    import torch
-    import diart.argdoc as argdoc
-    from diart.pipelines import PipelineConfig
-
     # Define script arguments
     parser = argparse.ArgumentParser()
     parser.add_argument("root", type=str, help="Directory with audio files CONVERSATION.(wav|flac|m4a|...)")

--- a/src/diart/blocks.py
+++ b/src/diart/blocks.py
@@ -368,6 +368,9 @@ class DelayedAggregation:
             )
         # Append rest of the outputs
         elif self.stream_end is not None and last_buffer.end == self.stream_end:
+            # FIXME instead of appending a larger chunk than expected when latency > step,
+            #  keep emitting windows until the signal ends.
+            #  This should be fixed at the observable level and not within the aggregation block.
             num_frames = output_window.data.shape[0]
             last_region = Segment(output_region.start, last_buffer.end)
             last_output = buffers[-1].crop(

--- a/src/diart/inference.py
+++ b/src/diart/inference.py
@@ -1,0 +1,102 @@
+from pathlib import Path
+from typing import Union, Text, Optional
+
+import pandas as pd
+import rx.operators as ops
+from pyannote.database.util import load_rttm
+from pyannote.metrics.diarization import DiarizationErrorRate
+
+import diart.operators as dops
+import diart.sources as src
+from diart.pipelines import OnlineSpeakerDiarization
+from diart.sinks import RTTMWriter, RealTimePlot
+
+
+class RealTimeInference:
+    def __init__(self, output_path: Union[Text, Path], do_plot: bool = True):
+        self.output_path = Path(output_path).expanduser()
+        self.output_path.mkdir(parents=True, exist_ok=True)
+        self.do_plot = do_plot
+
+    def __call__(self, pipeline: OnlineSpeakerDiarization, source: src.AudioSource):
+        rttm_writer = RTTMWriter(path=self.output_path / f"{source.uri}.rttm")
+        observable = pipeline.from_source(source).pipe(
+            dops.progress(f"Streaming {source.uri}", total=source.length, leave=True)
+        )
+        if not self.do_plot:
+            # Write RTTM file only
+            observable.subscribe(rttm_writer)
+        else:
+            # Write RTTM file + buffering and real-time plot
+            observable.pipe(
+                ops.do(rttm_writer),
+                dops.buffer_output(
+                    duration=pipeline.duration,
+                    step=pipeline.config.step,
+                    latency=pipeline.config.latency,
+                    sample_rate=pipeline.sample_rate
+                ),
+            ).subscribe(RealTimePlot(pipeline.duration, pipeline.config.latency))
+        # Stream audio through the pipeline
+        source.read()
+
+
+class Benchmark:
+    def __init__(
+        self,
+        speech_path: Union[Text, Path],
+        reference_path: Optional[Union[Text, Path]] = None,
+        output_path: Optional[Union[Text, Path]] = None,
+    ):
+        self.speech_path = Path(speech_path).expanduser()
+        assert self.speech_path.is_dir(), "Speech path must be a directory"
+
+        self.reference_path = reference_path
+        if reference_path is not None:
+            self.reference_path = Path(self.reference_path).expanduser()
+            assert self.reference_path.is_dir(), "Reference path must be a directory"
+
+        if output_path is None:
+            self.output_path = self.speech_path
+        else:
+            self.output_path = Path(output_path).expanduser()
+            self.output_path.mkdir(parents=True, exist_ok=True)
+
+    def __call__(self, pipeline: OnlineSpeakerDiarization, batch_size: int = 32) -> Optional[pd.DataFrame]:
+        # Run inference
+        chunk_loader = src.ChunkLoader(pipeline.sample_rate, pipeline.duration, pipeline.config.step)
+        for filepath in self.speech_path.iterdir():
+            num_chunks = chunk_loader.num_chunks(filepath)
+
+            # Stream fully online if batch size is 1 or lower
+            source = None
+            if batch_size < 2:
+                source = src.FileAudioSource(
+                    filepath,
+                    filepath.stem,
+                    src.RegularAudioFileReader(pipeline.sample_rate, pipeline.duration, pipeline.config.step),
+                    # Benchmark the processing time of a single chunk
+                    profile=True,
+                )
+                observable = pipeline.from_source(source, output_waveform=False)
+            else:
+                observable = pipeline.from_file(filepath, batch_size=batch_size, verbose=True)
+
+            observable.pipe(
+                dops.progress(f"Streaming {filepath.stem}", total=num_chunks, leave=source is None)
+            ).subscribe(
+                RTTMWriter(path=self.output_path / f"{filepath.stem}.rttm")
+            )
+
+            if source is not None:
+                source.read()
+
+        # Run evaluation
+        if self.reference_path is not None:
+            metric = DiarizationErrorRate(collar=0, skip_overlap=False)
+            for ref_path in self.reference_path.iterdir():
+                ref = load_rttm(ref_path).popitem()[1]
+                hyp = load_rttm(self.output_path / ref_path.name).popitem()[1]
+                metric(ref, hyp)
+
+            return metric.report(display=True)

--- a/src/diart/inference.py
+++ b/src/diart/inference.py
@@ -3,6 +3,7 @@ from typing import Union, Text, Optional
 
 import pandas as pd
 import rx.operators as ops
+from pyannote.core import Annotation
 from pyannote.database.util import load_rttm
 from pyannote.metrics.diarization import DiarizationErrorRate
 
@@ -13,13 +14,40 @@ from diart.sinks import RTTMWriter, RealTimePlot
 
 
 class RealTimeInference:
+    """
+    Streams an audio source to an online speaker diarization pipeline.
+    It writes predictions to an output directory in RTTM format, and also plot predictions in real time.
+
+    Parameters
+    ----------
+    output_path: Text or Path
+        Output directory to store predictions in RTTM format.
+    do_plot: bool
+        Whether to draw predictions in a moving plot. Defaults to True.
+    """
     def __init__(self, output_path: Union[Text, Path], do_plot: bool = True):
         self.output_path = Path(output_path).expanduser()
         self.output_path.mkdir(parents=True, exist_ok=True)
         self.do_plot = do_plot
 
-    def __call__(self, pipeline: OnlineSpeakerDiarization, source: src.AudioSource):
-        rttm_writer = RTTMWriter(path=self.output_path / f"{source.uri}.rttm")
+    def __call__(self, pipeline: OnlineSpeakerDiarization, source: src.AudioSource) -> Annotation:
+        """
+        Stream audio chunks from `source` to `pipeline` and write predictions to disk.
+
+        Parameters
+        ----------
+        pipeline: OnlineSpeakerDiarization
+            Configured speaker diarization pipeline.
+        source: AudioSource
+            Audio source to be read and streamed.
+
+        Returns
+        -------
+        predictions: Annotation
+            Speaker diarization pipeline predictions
+        """
+        rttm_path = self.output_path / f"{source.uri}.rttm"
+        rttm_writer = RTTMWriter(path=rttm_path)
         observable = pipeline.from_source(source).pipe(
             dops.progress(f"Streaming {source.uri}", total=source.length, leave=True)
         )
@@ -40,8 +68,25 @@ class RealTimeInference:
         # Stream audio through the pipeline
         source.read()
 
+        return load_rttm(rttm_path)[source.uri]
+
 
 class Benchmark:
+    """
+    Run an online speaker diarization pipeline on a set of audio files in batches.
+    It writes predictions to a given output directory.
+
+    If the reference is given, it calculates the average diarization error rate.
+
+    Parameters
+    ----------
+    speech_path: Text or Path
+        Directory with audio files.
+    reference_path: Text or Path
+        Directory with reference RTTM files (same names as audio files).
+    output_path: Text or Path
+        Output directory to store predictions in RTTM format.
+    """
     def __init__(
         self,
         speech_path: Union[Text, Path],
@@ -63,7 +108,23 @@ class Benchmark:
             self.output_path.mkdir(parents=True, exist_ok=True)
 
     def __call__(self, pipeline: OnlineSpeakerDiarization, batch_size: int = 32) -> Optional[pd.DataFrame]:
-        # Run inference
+        """
+        Run a given pipeline on a set of audio files using
+        pre-calculated segmentation and embeddings in batches.
+
+        Parameters
+        ----------
+        pipeline: OnlineSpeakerDiarization
+            Configured speaker diarization pipeline.
+        batch_size: int
+            Batch size. Defaults to 32.
+
+        Returns
+        -------
+        performance: pandas.DataFrame, optional
+            DataFrame with detailed performance on each file, as well as average performance.
+            None if the reference is not provided.
+        """
         chunk_loader = src.ChunkLoader(pipeline.sample_rate, pipeline.duration, pipeline.config.step)
         for filepath in self.speech_path.iterdir():
             num_chunks = chunk_loader.num_chunks(filepath)

--- a/src/diart/operators.py
+++ b/src/diart/operators.py
@@ -269,7 +269,10 @@ def buffer_output(
             else:
                 # The buffer is full, shift values to the left and copy into last buffer chunk
                 waveform = np.roll(state.waveform.data, -num_step_samples, axis=0)
-                waveform[-num_step_samples:] = value.waveform.data
+                # If running on a file, the online prediction may be shorter depending on the latency
+                # The remaining audio at the end is appended, so value.waveform may be longer than num_step_samples
+                # In that case, we simply ignore the appended samples.
+                waveform[-num_step_samples:] = value.waveform.data[:num_step_samples]
 
             # Wrap waveform in a sliding window feature to include timestamps
             window = SlidingWindow(start=start_time, duration=resolution, step=resolution)

--- a/src/diart/pipelines.py
+++ b/src/diart/pipelines.py
@@ -165,7 +165,7 @@ class OnlineSpeakerDiarization:
         file: Union[Text, Path],
         output_waveform: bool = False,
         batch_size: int = 32,
-        verbose: bool = False,
+        desc: Optional[Text] = None,
     ) -> rx.Observable:
         # Audio file information
         file = Path(file)
@@ -182,8 +182,7 @@ class OnlineSpeakerDiarization:
 
         # Set progress if needed
         iterator = range(0, num_chunks, batch_size)
-        if verbose:
-            desc = f"Pre-calculating {file.stem}"
+        if desc is not None:
             total = int(math.ceil(num_chunks / batch_size))
             iterator = tqdm(iterator, desc=desc, total=total, unit="batch", leave=False)
 

--- a/src/diart/stream.py
+++ b/src/diart/stream.py
@@ -1,79 +1,92 @@
-import argparse
 from pathlib import Path
+from typing import Union, Text
 
 import rx.operators as ops
-import torch
 
-import diart.argdoc as argdoc
 import diart.operators as dops
 import diart.sources as src
-from diart.pipelines import OnlineSpeakerDiarization, PipelineConfig
+from diart.pipelines import OnlineSpeakerDiarization
 from diart.sinks import RealTimePlot, RTTMWriter
 
-# Define script arguments
-parser = argparse.ArgumentParser()
-parser.add_argument("source", type=str, help="Path to an audio file | 'microphone'")
-parser.add_argument("--step", default=0.5, type=float, help=f"{argdoc.STEP}. Defaults to 0.5")
-parser.add_argument("--latency", default=0.5, type=float, help=f"{argdoc.LATENCY}. Defaults to 0.5")
-parser.add_argument("--tau", default=0.5, type=float, help=f"{argdoc.TAU}. Defaults to 0.5")
-parser.add_argument("--rho", default=0.3, type=float, help=f"{argdoc.RHO}. Defaults to 0.3")
-parser.add_argument("--delta", default=1, type=float, help=f"{argdoc.DELTA}. Defaults to 1")
-parser.add_argument("--gamma", default=3, type=float, help=f"{argdoc.GAMMA}. Defaults to 3")
-parser.add_argument("--beta", default=10, type=float, help=f"{argdoc.BETA}. Defaults to 10")
-parser.add_argument("--max-speakers", default=20, type=int, help=f"{argdoc.MAX_SPEAKERS}. Defaults to 20")
-parser.add_argument("--no-plot", dest="no_plot", action="store_true", help="Skip plotting for faster inference")
-parser.add_argument("--gpu", dest="gpu", action="store_true", help=argdoc.GPU)
-parser.add_argument("--output", type=str, help=f"{argdoc.OUTPUT}. Defaults to home directory if SOURCE == 'microphone' or parent directory if SOURCE is a file")
-args = parser.parse_args()
 
-# Define online speaker diarization pipeline
-config = PipelineConfig(
-    step=args.step,
-    latency=args.latency,
-    tau_active=args.tau,
-    rho_update=args.rho,
-    delta_new=args.delta,
-    gamma=args.gamma,
-    beta=args.beta,
-    max_speakers=args.max_speakers,
-    device=torch.device("cuda") if args.gpu else None,
-)
-pipeline = OnlineSpeakerDiarization(config)
+class RealTimeInference:
+    def __init__(self, output_path: Union[Text, Path], do_plot: bool = True):
+        self.output_path = Path(output_path).expanduser()
+        self.output_path.mkdir(parents=True, exist_ok=True)
+        self.do_plot = do_plot
 
-# Manage audio source
-if args.source != "microphone":
-    args.source = Path(args.source).expanduser()
-    output_dir = args.source.parent if args.output is None else Path(args.output)
-    audio_source = src.FileAudioSource(
-        file=args.source,
-        uri=args.source.stem,
-        reader=src.RegularAudioFileReader(
-            pipeline.sample_rate, pipeline.duration, config.step
-        ),
-    )
-else:
-    output_dir = Path("~/").expanduser() if args.output is None else Path(args.output)
-    audio_source = src.MicrophoneAudioSource(pipeline.sample_rate)
+    def __call__(self, pipeline: OnlineSpeakerDiarization, source: src.AudioSource):
+        rttm_writer = RTTMWriter(path=self.output_path / f"{source.uri}.rttm")
+        observable = pipeline.from_source(source).pipe(
+            dops.progress(f"Streaming {source.uri}", total=source.length, leave=True)
+        )
+        if not self.do_plot:
+            # Write RTTM file only
+            observable.subscribe(rttm_writer)
+        else:
+            # Write RTTM file + buffering and real-time plot
+            observable.pipe(
+                ops.do(rttm_writer),
+                dops.buffer_output(
+                    duration=pipeline.duration,
+                    step=pipeline.config.step,
+                    latency=pipeline.config.latency,
+                    sample_rate=pipeline.sample_rate
+                ),
+            ).subscribe(RealTimePlot(pipeline.duration, pipeline.config.latency))
+        # Stream audio through the pipeline
+        source.read()
 
-# Build pipeline from audio source and stream predictions
-rttm_writer = RTTMWriter(path=output_dir / f"{audio_source.uri}.rttm")
-observable = pipeline.from_source(audio_source).pipe(
-    dops.progress(f"Streaming {audio_source.uri}", total=audio_source.length, leave=True)
-)
-if args.no_plot:
-    # Write RTTM file only
-    observable.subscribe(rttm_writer)
-else:
-    # Write RTTM file + buffering and real-time plot
-    observable.pipe(
-        ops.do(rttm_writer),
-        dops.buffer_output(
-            duration=pipeline.duration,
-            step=config.step,
-            latency=config.latency,
-            sample_rate=pipeline.sample_rate
-        ),
-    ).subscribe(RealTimePlot(pipeline.duration, config.latency))
 
-# Read audio source as a stream
-audio_source.read()
+if __name__ == "__main__":
+    import argparse
+    import torch
+    import diart.argdoc as argdoc
+    from diart.pipelines import PipelineConfig
+
+    # Define script arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("source", type=str, help="Path to an audio file | 'microphone'")
+    parser.add_argument("--step", default=0.5, type=float, help=f"{argdoc.STEP}. Defaults to 0.5")
+    parser.add_argument("--latency", default=0.5, type=float, help=f"{argdoc.LATENCY}. Defaults to 0.5")
+    parser.add_argument("--tau", default=0.5, type=float, help=f"{argdoc.TAU}. Defaults to 0.5")
+    parser.add_argument("--rho", default=0.3, type=float, help=f"{argdoc.RHO}. Defaults to 0.3")
+    parser.add_argument("--delta", default=1, type=float, help=f"{argdoc.DELTA}. Defaults to 1")
+    parser.add_argument("--gamma", default=3, type=float, help=f"{argdoc.GAMMA}. Defaults to 3")
+    parser.add_argument("--beta", default=10, type=float, help=f"{argdoc.BETA}. Defaults to 10")
+    parser.add_argument("--max-speakers", default=20, type=int, help=f"{argdoc.MAX_SPEAKERS}. Defaults to 20")
+    parser.add_argument("--no-plot", dest="no_plot", action="store_true", help="Skip plotting for faster inference")
+    parser.add_argument("--gpu", dest="gpu", action="store_true", help=argdoc.GPU)
+    parser.add_argument("--output", type=str, help=f"{argdoc.OUTPUT}. Defaults to home directory if SOURCE == 'microphone' or parent directory if SOURCE is a file")
+    args = parser.parse_args()
+
+    # Define online speaker diarization pipeline
+    pipeline = OnlineSpeakerDiarization(PipelineConfig(
+        step=args.step,
+        latency=args.latency,
+        tau_active=args.tau,
+        rho_update=args.rho,
+        delta_new=args.delta,
+        gamma=args.gamma,
+        beta=args.beta,
+        max_speakers=args.max_speakers,
+        device=torch.device("cuda") if args.gpu else None,
+    ))
+
+    # Manage audio source
+    if args.source != "microphone":
+        args.source = Path(args.source).expanduser()
+        args.output = args.source.parent if args.output is None else Path(args.output)
+        audio_source = src.FileAudioSource(
+            file=args.source,
+            uri=args.source.stem,
+            reader=src.RegularAudioFileReader(
+                pipeline.sample_rate, pipeline.duration, pipeline.config.step
+            ),
+        )
+    else:
+        args.output = Path("~/").expanduser() if args.output is None else Path(args.output)
+        audio_source = src.MicrophoneAudioSource(pipeline.sample_rate)
+
+    # Run online inference
+    RealTimeInference(args.output, do_plot=not args.no_plot)(pipeline, audio_source)


### PR DESCRIPTION
This PR addresses #49 and #54.

## Changelog

- Add `__name__ == "__main__"` check to `diart.stream` and `diart.benchmark`
- Fix crash in `buffer_output()` at the end of the stream
- Add `RealTimeInference` as a python API for `diart.stream`
- Add `Benchmark` as a python API for `diart.benchmark`
- Pad last incomplete chunk with zeros in `ChunkLoader`