### PR TITLE
Fix bug: RTTM output not being patched when closing plot window

### DIFF
--- a/src/diart/sinks.py
+++ b/src/diart/sinks.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from traceback import print_exc
 from typing import Union, Text, Optional, Tuple
 
 import matplotlib.pyplot as plt
@@ -49,7 +48,6 @@ class RTTMWriter(Observer):
 
     def on_error(self, error: Exception):
         self.patch()
-        print_exc()
 
     def on_completed(self):
         self.patch()
@@ -82,7 +80,6 @@ class DiarizationPredictionAccumulator(Observer):
 
     def on_error(self, error: Exception):
         self.patch()
-        print_exc()
 
     def on_completed(self):
         self.patch()


### PR DESCRIPTION
## Changelog

- Keep a list of observers in `RealTimeInference` to call `on_error` appropriately
  - It seems that Rx doesn't call `on_error` on side effect observers consistently
- Write RTTM files at the end of the stream in `Benchmark` instead of writing at each prediction
- Remove stacktrace printing from sinks