### PR TITLE
Plug & play speaker diarization pipelines

### DIFF
--- a/src/diart/__init__.py
+++ b/src/diart/__init__.py
@@ -1,1 +1,6 @@
-from .blocks import OnlineSpeakerDiarization, PipelineConfig
+from .blocks import (
+    OnlineSpeakerDiarization,
+    BasePipeline,
+    PipelineConfig,
+    BasePipelineConfig,
+)

--- a/src/diart/blocks/__init__.py
+++ b/src/diart/blocks/__init__.py
@@ -13,5 +13,10 @@ from .embedding import (
     OverlapAwareSpeakerEmbedding,
 )
 from .segmentation import SpeakerSegmentation
-from .diarization import OnlineSpeakerDiarization, PipelineConfig
+from .diarization import (
+    OnlineSpeakerDiarization,
+    BasePipeline,
+    PipelineConfig,
+    BasePipelineConfig,
+)
 from .utils import Binarize, Resample, AdjustVolume

--- a/src/diart/inference.py
+++ b/src/diart/inference.py
@@ -9,8 +9,8 @@ import numpy as np
 import pandas as pd
 import rx
 import rx.operators as ops
-from diart.blocks import OnlineSpeakerDiarization, Resample
-from diart.sinks import DiarizationPredictionAccumulator, RTTMWriter, RealTimePlot, WindowClosedException
+from diart.blocks import BasePipeline, Resample
+from diart.sinks import DiarizationPredictionAccumulator, RealTimePlot, WindowClosedException
 from diart.utils import Chronometer
 from pyannote.core import Annotation, SlidingWindowFeature
 from pyannote.database.util import load_rttm
@@ -27,7 +27,7 @@ class RealTimeInference:
 
     Parameters
     ----------
-    pipeline: OnlineSpeakerDiarization
+    pipeline: BasePipeline
         Configured speaker diarization pipeline.
     source: AudioSource
         Audio source to be read and streamed.
@@ -52,7 +52,7 @@ class RealTimeInference:
     """
     def __init__(
         self,
-        pipeline: OnlineSpeakerDiarization,
+        pipeline: BasePipeline,
         source: src.AudioSource,
         batch_size: int = 1,
         do_profile: bool = True,
@@ -264,13 +264,13 @@ class Benchmark:
         self.show_report = show_report
         self.batch_size = batch_size
 
-    def __call__(self, pipeline: OnlineSpeakerDiarization) -> Union[pd.DataFrame, List[Annotation]]:
+    def __call__(self, pipeline: BasePipeline) -> Union[pd.DataFrame, List[Annotation]]:
         """Run a given pipeline on a set of audio files.
         Notice that the internal state of the pipeline is reset before benchmarking.
 
         Parameters
         ----------
-        pipeline: OnlineSpeakerDiarization
+        pipeline: BasePipeline
             Configured speaker diarization pipeline.
 
         Returns

--- a/src/diart/optim.py
+++ b/src/diart/optim.py
@@ -95,10 +95,11 @@ class Optimizer:
     def objective(self, trial: Trial) -> float:
         # Set suggested values for optimized hyper-parameters
         trial_config = vars(self.base_config)
-        for hparam in self.hparams:
-            trial_config[hparam.name] = trial.suggest_uniform(
-                hparam.name, hparam.low, hparam.high
-            )
+        if trial.number > 0:
+            for hparam in self.hparams:
+                trial_config[hparam.name] = trial.suggest_uniform(
+                    hparam.name, hparam.low, hparam.high
+                )
 
         # Prune trial if required
         if trial.should_prune():

--- a/src/diart/optim.py
+++ b/src/diart/optim.py
@@ -95,11 +95,10 @@ class Optimizer:
     def objective(self, trial: Trial) -> float:
         # Set suggested values for optimized hyper-parameters
         trial_config = vars(self.base_config)
-        if trial.number > 0:
-            for hparam in self.hparams:
-                trial_config[hparam.name] = trial.suggest_uniform(
-                    hparam.name, hparam.low, hparam.high
-                )
+        for hparam in self.hparams:
+            trial_config[hparam.name] = trial.suggest_uniform(
+                hparam.name, hparam.low, hparam.high
+            )
 
         # Prune trial if required
         if trial.should_prune():
@@ -122,4 +121,9 @@ class Optimizer:
             if self.study.trials:
                 last_trial = self.study.trials[-1].number
             self._progress.set_description(f"Trial {last_trial + 1}")
+        # Start with base config hyper-parameters
+        self.study.enqueue_trial({
+            param.name: getattr(self.base_config, param.name)
+            for param in self.hparams
+        })
         self.study.optimize(self.objective, num_iter, callbacks=[self._callback])


### PR DESCRIPTION
This PR addresses issue #96 and introduces a new feature for custom pipelines.

## Changelog

- Add `BasePipelineConfig` and `BasePipeline` as minimal interfaces to respect for custom pipelines
  - A config must provide `sample_rate`, `duration`, `step` and `latency`
  - A pipeline must provide a config, it must be callable and be able to reset its internal state
- Make `RealTimeInference`, `Benchmark` and `Optimizer` fully compatible with any pipeline adhering to the interface
- Fix bug #96 

The next step for custom pipelines would be that the CLI interface supports it, which is a bit more complicated because the CLI also builds the config.