### PR TITLE
Add left padding to short audio files

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,10 @@ class MyEmbeddingModel(EmbeddingModel):
         return self.model(waveform, weights)
 
     
-config = PipelineConfig(embedding=MyEmbeddingModel())
+config = PipelineConfig(
+    segmentation=MySegmentationModel(),
+    embedding=MyEmbeddingModel()
+)
 pipeline = OnlineSpeakerDiarization(config)
 mic = MicrophoneAudioSource(config.sample_rate)
 inference = RealTimeInference(pipeline, mic)

--- a/src/diart/console/stream.py
+++ b/src/diart/console/stream.py
@@ -38,12 +38,12 @@ def run():
     pipeline = OnlineSpeakerDiarization(config)
 
     # Manage audio source
-    block_size = int(np.rint(config.step * config.sample_rate))
+    block_size = config.optimal_block_size()
     if args.source != "microphone":
         args.source = Path(args.source).expanduser()
         args.output = args.source.parent if args.output is None else Path(args.output)
-        stream_padding = config.latency - config.step
-        audio_source = src.FileAudioSource(args.source, config.sample_rate, stream_padding, block_size)
+        padding = config.get_file_padding(args.source)
+        audio_source = src.FileAudioSource(args.source, config.sample_rate, padding, block_size)
     else:
         args.output = Path("~/").expanduser() if args.output is None else Path(args.output)
         audio_source = src.MicrophoneAudioSource(config.sample_rate, block_size)

--- a/src/diart/sinks.py
+++ b/src/diart/sinks.py
@@ -33,6 +33,8 @@ class RTTMWriter(Observer):
 
     def patch(self):
         """Stitch same-speaker turns that are close to each other"""
+        if not self.path.exists():
+            return
         annotations = list(load_rttm(self.path).values())
         if annotations:
             annotation = annotations[0]

--- a/src/diart/utils.py
+++ b/src/diart/utils.py
@@ -68,6 +68,16 @@ def decode_audio(data: Text) -> np.ndarray:
     return samples.reshape(1, -1)
 
 
+def get_padding_left(stream_duration: float, chunk_duration: float) -> float:
+    if stream_duration < chunk_duration:
+        return chunk_duration - stream_duration
+    return 0
+
+
+def get_padding_right(latency: float, step: float) -> float:
+    return latency - step
+
+
 def visualize_feature(duration: Optional[float] = None):
     def apply(feature: SlidingWindowFeature):
         if duration is None:


### PR DESCRIPTION
This PR addresses issue #118.

## Changelog
- Check that output RTTM file exists before patching to avoid crashes
- `BasePipelineConfig` can now determine padding for files and suggest a block size for the audio source
- Add left padding to short audio files so that they can form at least 1 chunk