### PR TITLE
Allow to select microphone device

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ diart.stream /path/to/audio.wav
 A live conversation:
 
 ```shell
+# Use "microphone:ID" to select a non-default device
+# See `python -m sounddevice` for available devices
 diart.stream microphone
 ```
 

--- a/src/diart/console/client.py
+++ b/src/diart/console/client.py
@@ -14,10 +14,12 @@ from websocket import WebSocket
 def send_audio(ws: WebSocket, source: Text, step: float, sample_rate: int):
     # Create audio source
     block_size = int(np.rint(step * sample_rate))
-    if source != "microphone":
+    source_components = source.split(":")
+    if source_components[0] != "microphone":
         audio_source = src.FileAudioSource(source, sample_rate)
     else:
-        audio_source = src.MicrophoneAudioSource(sample_rate, block_size)
+        device = int(source_components[1]) if len(source_components) > 1 else None
+        audio_source = src.MicrophoneAudioSource(sample_rate, block_size, device)
 
     # Encode audio, then send through websocket
     audio_source.stream.pipe(
@@ -39,7 +41,7 @@ def receive_audio(ws: WebSocket, output: Optional[Path]):
 
 def run():
     parser = argparse.ArgumentParser()
-    parser.add_argument("source", type=str, help="Path to an audio file | 'microphone'")
+    parser.add_argument("source", type=str, help="Path to an audio file | 'microphone' | 'microphone:<DEVICE_ID>'")
     parser.add_argument("--host", required=True, type=str, help="Server host")
     parser.add_argument("--port", required=True, type=int, help="Server port")
     parser.add_argument("--step", default=0.5, type=float, help=f"{argdoc.STEP}. Defaults to 0.5")

--- a/src/diart/sources.py
+++ b/src/diart/sources.py
@@ -127,9 +127,27 @@ class FileAudioSource(AudioSource):
 
 
 class MicrophoneAudioSource(AudioSource):
-    """Represents an audio source tied to the default microphone available"""
+    """Audio source tied to a local microphone.
 
-    def __init__(self, sample_rate: int, block_size: int = 1000):
+    Parameters
+    ----------
+    sample_rate: int
+        Sample rate for the emitted audio chunks.
+    block_size: int
+        Number of samples per chunk emitted.
+        Defaults to 1000.
+    device: int | str | (int, str) | None
+        Device identifier compatible for the sounddevice stream.
+        If None, use the default device.
+        Defaults to None.
+    """
+
+    def __init__(
+        self,
+        sample_rate: int,
+        block_size: int = 1000,
+        device: Optional[Union[int, Text, Tuple[int, Text]]] = None,
+    ):
         super().__init__("live_recording", sample_rate)
         self.block_size = block_size
         self._mic_stream = sd.InputStream(
@@ -137,7 +155,8 @@ class MicrophoneAudioSource(AudioSource):
             samplerate=sample_rate,
             latency=0,
             blocksize=self.block_size,
-            callback=self._read_callback
+            callback=self._read_callback,
+            device=device,
         )
         self._queue = SimpleQueue()
 


### PR DESCRIPTION
This PR addresses issue #99.

## Changelog

- Add `device` parameter to `MicrophoneAudioSource`
- Add possiblity to set device with ID number X using `diart.stream microphone:X` (also works in `diart.client`)
- Add short explanation in README