### PR TITLE
Shift pipeline timestamps

### DIFF
--- a/src/diart/console/stream.py
+++ b/src/diart/console/stream.py
@@ -44,6 +44,7 @@ def run():
         args.output = args.source.parent if args.output is None else Path(args.output)
         padding = config.get_file_padding(args.source)
         audio_source = src.FileAudioSource(args.source, config.sample_rate, padding, block_size)
+        pipeline.set_timestamp_shift(-padding[0])
     else:
         args.output = Path("~/").expanduser() if args.output is None else Path(args.output)
         device = int(source_components[1]) if len(source_components) > 1 else None

--- a/src/diart/inference.py
+++ b/src/diart/inference.py
@@ -310,12 +310,14 @@ class Benchmark:
         prediction: Annotation
             Pipeline prediction for the given file.
         """
+        padding = pipeline.config.get_file_padding(filepath)
         source = src.FileAudioSource(
             filepath,
             pipeline.config.sample_rate,
-            pipeline.config.get_file_padding(filepath),
+            padding,
             pipeline.config.optimal_block_size(),
         )
+        pipeline.set_timestamp_shift(-padding[0])
         inference = RealTimeInference(
             pipeline,
             source,


### PR DESCRIPTION
If left padding is added to a file (e.g. because it is too short), then the annotations produced by the pipeline will be shifted right by the padding. This PR fixes this problem.

## Changelog
- Add `set_timestamp_shift()` to `OnlineSpeakerDiarization` and `BasePipeline`