### PR TITLE
Add S3 source to `diart.benchmark`

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,36 @@ if __name__ == "__main__":  # Needed for multiprocessing
 This pre-calculates model outputs in batches, so it runs a lot faster.
 See `diart.benchmark -h` for more options.
 
+### Benchmark from AWS S3
+
+The audio and reference directories also accept remote `s3://` URLs, so you can
+benchmark a corpus stored on AWS S3 without downloading it first. Install the
+optional dependencies:
+
+```shell
+pip install diart[s3]
+```
+
+Then point `diart.benchmark` (or `Benchmark`) at `s3://` prefixes:
+
+```shell
+diart.benchmark s3://my-bucket/audio --reference s3://my-bucket/rttm
+```
+
+```python
+from diart.inference import Benchmark
+
+benchmark = Benchmark("s3://my-bucket/audio", "s3://my-bucket/rttm")
+```
+
+As with local benchmarks, RTTM file names must match the audio file names
+(e.g. `audio/conversation.wav` ↔ `rttm/conversation.rttm`). AWS credentials are
+resolved through the standard chain (environment variables,
+`~/.aws/credentials`, or an IAM role). Under the hood this uses
+[fsspec](https://filesystem-spec.readthedocs.io)/[s3fs](https://s3fs.readthedocs.io),
+so other supported protocols such as `gs://` work too once their backend is
+installed. The `--output` directory remains local.
+
 For convenience and to facilitate future comparisons, we also provide the
 <a href="https://github.com/juanmc2005/diart/tree/main/expected_outputs">expected outputs</a>
 of the paper implementation in RTTM format for every entry of Table 1 and Figure 5.

--- a/README.md
+++ b/README.md
@@ -456,15 +456,9 @@ See `diart.benchmark -h` for more options.
 
 ### Benchmark from AWS S3
 
-The audio and reference directories also accept remote `s3://` URLs, so you can
-benchmark a corpus stored on AWS S3 without downloading it first. Install the
-optional dependencies:
-
-```shell
-pip install diart[s3]
-```
-
-Then point `diart.benchmark` (or `Benchmark`) at `s3://` prefixes:
+The audio and reference directories also accept remote `s3://` URLs out of the
+box, so you can benchmark a corpus stored on AWS S3 without downloading it
+first. Just point `diart.benchmark` (or `Benchmark`) at `s3://` prefixes:
 
 ```shell
 diart.benchmark s3://my-bucket/audio --reference s3://my-bucket/rttm

--- a/README.md
+++ b/README.md
@@ -423,10 +423,10 @@ or using the inference API:
 
 ```python
 from diart.inference import Benchmark, Parallelize
-from diart import SpeakerDiarization, SpeakerDiarizationConfig
+from diart import Dataset, SpeakerDiarization, SpeakerDiarizationConfig
 from diart.models import SegmentationModel
 
-benchmark = Benchmark("/wav/dir", "/rttm/dir")
+benchmark = Benchmark(Dataset("/wav/dir", "/rttm/dir"))
 
 model_name = "pyannote/segmentation@Interspeech2021"
 model = SegmentationModel.from_pretrained(model_name)
@@ -467,9 +467,10 @@ diart.benchmark s3://my-bucket/audio --reference s3://my-bucket/rttm
 ```
 
 ```python
+from diart import Dataset
 from diart.inference import Benchmark
 
-benchmark = Benchmark("s3://my-bucket/audio", "s3://my-bucket/rttm")
+benchmark = Benchmark(Dataset("s3://my-bucket/audio", "s3://my-bucket/rttm"))
 ```
 
 As with local benchmarks, RTTM file names must match the audio file names

--- a/README.md
+++ b/README.md
@@ -249,9 +249,11 @@ See `diart.tune -h` for more options.
 ### From python
 
 ```python
+from diart import Dataset, SpeakerDiarization
 from diart.optim import Optimizer
 
-optimizer = Optimizer("/wav/dir", "/rttm/dir", "/output/dir")
+dataset = Dataset("/wav/dir", "/rttm/dir")
+optimizer = Optimizer(SpeakerDiarization, dataset, "/output/dir")
 optimizer(num_iter=100)
 ```
 
@@ -276,13 +278,15 @@ diart.tune /wav/dir --reference /rttm/dir --storage mysql://root@localhost/examp
 or in python:
 
 ```python
+from diart import Dataset, SpeakerDiarization
 from diart.optim import Optimizer
 from optuna.samplers import TPESampler
 import optuna
 
 db = "mysql://root@localhost/example"
 study = optuna.load_study("example", db, TPESampler())
-optimizer = Optimizer("/wav/dir", "/rttm/dir", study)
+dataset = Dataset("/wav/dir", "/rttm/dir")
+optimizer = Optimizer(SpeakerDiarization, dataset, study)
 optimizer(num_iter=100)
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ docs = [
     "sphinx-mdinclude>=0.6.0",
     "furo>=2024.1.29",
 ]
+s3 = [
+    "s3fs>=2024.0.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/juanmc2005/diart"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ dependencies = [
     "websocket-client>=1.7.0",
     "rich>=13.0.0",
     "omegaconf>=2.3.0",
+    "fsspec>=2024.0.0",
+    "s3fs>=2024.0.0",
 ]
 
 [project.optional-dependencies]
@@ -63,9 +65,6 @@ docs = [
     "sphinx-autoapi>=3.0.0",
     "sphinx-mdinclude>=0.6.0",
     "furo>=2024.1.29",
-]
-s3 = [
-    "s3fs>=2024.0.0",
 ]
 
 [project.urls]

--- a/src/diart/__init__.py
+++ b/src/diart/__init__.py
@@ -6,5 +6,6 @@ from .blocks import (
     VoiceActivityDetection,
     VoiceActivityDetectionConfig,
 )
+from .storage import Dataset, FilePath
 
 __version__ = "0.9.2"

--- a/src/diart/audio.py
+++ b/src/diart/audio.py
@@ -1,10 +1,9 @@
-from pathlib import Path
-from typing import Text, Union
-
 import torch
 from torchcodec.decoders import AudioDecoder
 
-FilePath = Union[Text, Path]
+from .storage import FilePath, PathLike
+
+__all__ = ["AudioLoader", "FilePath", "PathLike"]
 
 
 class AudioLoader:
@@ -12,38 +11,41 @@ class AudioLoader:
         self.sample_rate = sample_rate
         self.mono = mono
 
-    def load(self, filepath: FilePath) -> torch.Tensor:
+    def load(self, filepath: PathLike) -> torch.Tensor:
         """Load an audio file into a torch.Tensor.
 
         Parameters
         ----------
-        filepath : FilePath
-            Path to an audio file
+        filepath : PathLike
+            Path to an audio file (local or remote).
 
         Returns
         -------
         waveform : torch.Tensor, shape (channels, samples)
         """
-        # torchcodec resamples to the target sample rate while decoding
-        decoder = AudioDecoder(str(filepath), sample_rate=self.sample_rate)
-        waveform = decoder.get_all_samples().data
+        # torchcodec resamples to the target sample rate while decoding.
+        # localize() downloads remote files and is a no-op for local ones.
+        with FilePath(filepath).localize() as local:
+            decoder = AudioDecoder(str(local), sample_rate=self.sample_rate)
+            waveform = decoder.get_all_samples().data
         # Get channel mean if mono
         if self.mono and waveform.shape[0] > 1:
             waveform = waveform.mean(dim=0, keepdim=True)
         return waveform
 
     @staticmethod
-    def get_duration(filepath: FilePath) -> float:
+    def get_duration(filepath: PathLike) -> float:
         """Get audio file duration in seconds.
 
         Parameters
         ----------
-        filepath : FilePath
-            Path to an audio file.
+        filepath : PathLike
+            Path to an audio file (local or remote).
 
         Returns
         -------
         duration : float
             Duration in seconds.
         """
-        return AudioDecoder(str(filepath)).metadata.duration_seconds
+        with FilePath(filepath).localize() as local:
+            return AudioDecoder(str(local)).metadata.duration_seconds

--- a/src/diart/blocks/base.py
+++ b/src/diart/blocks/base.py
@@ -6,7 +6,7 @@ from pyannote.core import SlidingWindowFeature
 from pyannote.metrics.base import BaseMetric
 
 from .. import utils
-from ..audio import AudioLoader, FilePath
+from ..audio import AudioLoader, PathLike
 
 
 @dataclass
@@ -78,7 +78,7 @@ class PipelineConfig(ABC):
         """The sample rate of the input audio stream"""
         pass
 
-    def get_file_padding(self, filepath: FilePath) -> Tuple[float, float]:
+    def get_file_padding(self, filepath: PathLike) -> Tuple[float, float]:
         file_duration = AudioLoader(self.sample_rate, mono=True).get_duration(filepath)
         right = utils.get_padding_right(self.latency, self.step)
         left = utils.get_padding_left(file_duration + right, self.duration)

--- a/src/diart/console/benchmark.py
+++ b/src/diart/console/benchmark.py
@@ -7,6 +7,7 @@ import torch
 from diart import argdoc, utils
 from diart import models as m
 from diart.inference import Benchmark, Parallelize
+from diart.storage import Dataset
 
 
 def run():
@@ -119,8 +120,7 @@ def run():
     pipeline_class = utils.get_pipeline_class(args.pipeline)
 
     benchmark = Benchmark(
-        args.root,
-        args.reference,
+        Dataset(args.root, args.reference),
         args.output,
         show_progress=True,
         show_report=True,

--- a/src/diart/console/benchmark.py
+++ b/src/diart/console/benchmark.py
@@ -13,8 +13,9 @@ def run():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "root",
-        type=Path,
-        help="Directory with audio files CONVERSATION.(wav|flac|m4a|...)",
+        type=str,
+        help="Directory with audio files CONVERSATION.(wav|flac|m4a|...). "
+        "Also accepts remote URLs such as s3://my-bucket/audio (requires diart[s3])",
     )
     parser.add_argument(
         "--pipeline",
@@ -36,8 +37,9 @@ def run():
     )
     parser.add_argument(
         "--reference",
-        type=Path,
-        help="Optional. Directory with RTTM files CONVERSATION.rttm. Names must match audio files",
+        type=str,
+        help="Optional. Directory with RTTM files CONVERSATION.rttm. Names must match audio files. "
+        "Also accepts remote URLs such as s3://my-bucket/rttm (requires diart[s3])",
     )
     parser.add_argument(
         "--duration",

--- a/src/diart/console/tune.py
+++ b/src/diart/console/tune.py
@@ -9,6 +9,7 @@ from diart import argdoc, utils
 from diart import models as m
 from diart.blocks.base import HyperParameter
 from diart.optim import Optimizer
+from diart.storage import Dataset
 
 
 def run():
@@ -157,8 +158,7 @@ def run():
     # Run optimization
     Optimizer(
         pipeline_class=pipeline_class,
-        speech_path=args.root,
-        reference_path=args.reference,
+        dataset=Dataset(args.root, args.reference),
         study_or_path=study_or_path,
         batch_size=args.batch_size,
         hparams=hparams,

--- a/src/diart/inference.py
+++ b/src/diart/inference.py
@@ -15,11 +15,12 @@ from pyannote.metrics.base import BaseMetric
 from rx.core import Observer
 from tqdm import tqdm
 
-from . import blocks, storage, utils
+from . import blocks, utils
 from . import operators as dops
 from . import sources as src
 from .progress import ProgressBar, RichProgressBar, TQDMProgressBar
 from .sinks import PredictionAccumulator, StreamingPlot, WindowClosedException
+from .storage import Dataset, FilePath
 
 
 class StreamingInference:
@@ -239,12 +240,9 @@ class Benchmark:
 
     Parameters
     ----------
-    speech_path: Text or Path
-        Directory with audio files.
-    reference_path: Text, Path or None
-        Directory with reference RTTM files (same names as audio files).
-        If None, performance will not be calculated.
-        Defaults to None.
+    dataset: Dataset
+        Dataset with audio files and optional reference RTTM files.
+        If the dataset has no reference, performance will not be calculated.
     output_path: Text, Path or None
         Output directory to store predictions in RTTM format.
         If None, predictions will not be written to disk.
@@ -266,37 +264,17 @@ class Benchmark:
 
     def __init__(
         self,
-        speech_path: Union[Text, Path],
-        reference_path: Optional[Union[Text, Path]] = None,
+        dataset: Dataset,
         output_path: Optional[Union[Text, Path]] = None,
         show_progress: bool = True,
         show_report: bool = True,
         batch_size: int = 32,
     ):
-        # Remote paths (e.g. s3://) are kept as strings; local paths use pathlib.
-        if storage.is_remote(speech_path):
-            self.speech_path = str(speech_path)
-            assert storage.exists(self.speech_path), "Speech path must be a directory"
-        else:
-            self.speech_path = Path(speech_path).expanduser()
-            assert self.speech_path.is_dir(), "Speech path must be a directory"
+        self.dataset = dataset
 
         # If there's no reference and no output, then benchmark has no output
-        msg = "Benchmark expected reference path, output path or both"
-        assert reference_path is not None or output_path is not None, msg
-
-        self.reference_path = reference_path
-        if reference_path is not None:
-            if storage.is_remote(reference_path):
-                self.reference_path = str(reference_path)
-                assert storage.exists(self.reference_path), (
-                    "Reference path must be a directory"
-                )
-            else:
-                self.reference_path = Path(self.reference_path).expanduser()
-                assert self.reference_path.is_dir(), (
-                    "Reference path must be a directory"
-                )
+        msg = "Benchmark expected a dataset with a reference, an output path, or both"
+        assert self.dataset.has_reference or output_path is not None, msg
 
         self.output_path = output_path
         if self.output_path is not None:
@@ -307,22 +285,20 @@ class Benchmark:
         self.show_report = show_report
         self.batch_size = batch_size
 
-    def get_file_paths(self) -> List[Path]:
+    def get_file_paths(self) -> List[FilePath]:
         """Return the path for each file in the benchmark.
 
         Returns
         -------
-        paths: List[Path]
+        paths: List[FilePath]
             List of audio file paths.
         """
-        if storage.is_remote(self.speech_path):
-            return storage.list_audio_files(self.speech_path)
-        return list(self.speech_path.iterdir())
+        return self.dataset.audio_files()
 
     def run_single(
         self,
         pipeline: blocks.Pipeline,
-        filepath: Path,
+        file: FilePath,
         progress_bar: ProgressBar,
     ) -> Annotation:
         """Run a given pipeline on a given file.
@@ -333,7 +309,7 @@ class Benchmark:
         ----------
         pipeline: StreamingPipeline
             Speaker diarization pipeline to run.
-        filepath: Path
+        file: FilePath
             Path to the target file.
         progress_bar: diart.progress.ProgressBar
             An object to manage the progress of this run.
@@ -343,11 +319,11 @@ class Benchmark:
         prediction: Annotation
             Pipeline prediction for the given file.
         """
-        # Download remote files (e.g. s3://) once to a temporary local copy.
-        with storage.localize(filepath) as local_filepath:
-            padding = pipeline.config.get_file_padding(local_filepath)
+        # Ensure the file exists locally before running the pipeline
+        with file.localize() as local_file:
+            padding = pipeline.config.get_file_padding(local_file)
             source = src.FileAudioSource(
-                local_filepath,
+                local_file,
                 pipeline.config.sample_rate,
                 padding,
                 pipeline.config.step,
@@ -393,18 +369,13 @@ class Benchmark:
             A performance report as a pandas `DataFrame` if a
             reference path was given. Otherwise return the same predictions.
         """
-        if self.reference_path is not None:
+        if self.dataset.has_reference:
             progress_bar = TQDMProgressBar(f"Computing {metric.name}", leave=False)
             progress_bar.create(total=len(predictions), unit="file")
             progress_bar.start()
-            is_remote_ref = storage.is_remote(self.reference_path)
             for hyp in predictions:
-                if is_remote_ref:
-                    ref_path = f"{str(self.reference_path).rstrip('/')}/{hyp.uri}.rttm"
-                else:
-                    ref_path = self.reference_path / f"{hyp.uri}.rttm"
-                with storage.localize(ref_path) as local_ref:
-                    ref = load_rttm(local_ref).popitem()[1]
+                with self.dataset.reference_for(hyp.uri).localize() as local_ref:
+                    ref = load_rttm(str(local_ref)).popitem()[1]
                 metric(ref, hyp)
                 progress_bar.update()
             progress_bar.close()
@@ -444,11 +415,11 @@ class Benchmark:
         pipeline = pipeline_class(config)
 
         predictions = []
-        for i, filepath in enumerate(audio_file_paths):
+        for i, file in enumerate(audio_file_paths):
             pipeline.reset()
-            desc = f"Streaming {storage.get_stem(filepath)} ({i + 1}/{num_audio_files})"
+            desc = f"Streaming {file.stem} ({i + 1}/{num_audio_files})"
             progress = TQDMProgressBar(desc, leave=False, do_close=True)
-            predictions.append(self.run_single(pipeline, filepath, progress))
+            predictions.append(self.run_single(pipeline, file, progress))
 
         metric = pipeline.suggest_metric() if metric is None else metric
         return self.evaluate(predictions, metric)
@@ -479,7 +450,7 @@ class Parallelize:
         self,
         pipeline_class: type,
         config: blocks.PipelineConfig,
-        filepath: Path,
+        file: FilePath,
         description: Text,
     ) -> Annotation:
         """Build and run a pipeline on a single file.
@@ -492,7 +463,7 @@ class Parallelize:
             A pipeline from this class will be instantiated.
         config: StreamingConfig
             Streaming pipeline configuration.
-        filepath: Path
+        file: FilePath
             Path to the target file.
         description: Text
             Description to show in the parallel progress bar.
@@ -512,7 +483,7 @@ class Parallelize:
             description, leave=False, position=idx_process, do_close=True
         )
         # Run the pipeline
-        return self.benchmark.run_single(pipeline, filepath, progress)
+        return self.benchmark.run_single(pipeline, file, progress)
 
     def __call__(
         self,
@@ -564,10 +535,10 @@ class Parallelize:
             (
                 pipeline_class,
                 config,
-                filepath,
-                f"Streaming {storage.get_stem(filepath)} ({i + 1}/{num_audio_files})",
+                file,
+                f"Streaming {file.stem} ({i + 1}/{num_audio_files})",
             )
-            for i, filepath in enumerate(audio_file_paths)
+            for i, file in enumerate(audio_file_paths)
         ]
         # Submit all jobs
         jobs = [pool.apply_async(self.run_single_job, args=args) for args in arg_list]

--- a/src/diart/inference.py
+++ b/src/diart/inference.py
@@ -15,7 +15,7 @@ from pyannote.metrics.base import BaseMetric
 from rx.core import Observer
 from tqdm import tqdm
 
-from . import blocks, utils
+from . import blocks, storage, utils
 from . import operators as dops
 from . import sources as src
 from .progress import ProgressBar, RichProgressBar, TQDMProgressBar
@@ -273,8 +273,13 @@ class Benchmark:
         show_report: bool = True,
         batch_size: int = 32,
     ):
-        self.speech_path = Path(speech_path).expanduser()
-        assert self.speech_path.is_dir(), "Speech path must be a directory"
+        # Remote paths (e.g. s3://) are kept as strings; local paths use pathlib.
+        if storage.is_remote(speech_path):
+            self.speech_path = str(speech_path)
+            assert storage.exists(self.speech_path), "Speech path must be a directory"
+        else:
+            self.speech_path = Path(speech_path).expanduser()
+            assert self.speech_path.is_dir(), "Speech path must be a directory"
 
         # If there's no reference and no output, then benchmark has no output
         msg = "Benchmark expected reference path, output path or both"
@@ -282,8 +287,16 @@ class Benchmark:
 
         self.reference_path = reference_path
         if reference_path is not None:
-            self.reference_path = Path(self.reference_path).expanduser()
-            assert self.reference_path.is_dir(), "Reference path must be a directory"
+            if storage.is_remote(reference_path):
+                self.reference_path = str(reference_path)
+                assert storage.exists(self.reference_path), (
+                    "Reference path must be a directory"
+                )
+            else:
+                self.reference_path = Path(self.reference_path).expanduser()
+                assert self.reference_path.is_dir(), (
+                    "Reference path must be a directory"
+                )
 
         self.output_path = output_path
         if self.output_path is not None:
@@ -302,6 +315,8 @@ class Benchmark:
         paths: List[Path]
             List of audio file paths.
         """
+        if storage.is_remote(self.speech_path):
+            return storage.list_audio_files(self.speech_path)
         return list(self.speech_path.iterdir())
 
     def run_single(
@@ -328,26 +343,28 @@ class Benchmark:
         prediction: Annotation
             Pipeline prediction for the given file.
         """
-        padding = pipeline.config.get_file_padding(filepath)
-        source = src.FileAudioSource(
-            filepath,
-            pipeline.config.sample_rate,
-            padding,
-            pipeline.config.step,
-        )
-        pipeline.set_timestamp_shift(-padding[0])
-        inference = StreamingInference(
-            pipeline,
-            source,
-            self.batch_size,
-            do_profile=False,
-            do_plot=False,
-            show_progress=self.show_progress,
-            progress_bar=progress_bar,
-        )
+        # Download remote files (e.g. s3://) once to a temporary local copy.
+        with storage.localize(filepath) as local_filepath:
+            padding = pipeline.config.get_file_padding(local_filepath)
+            source = src.FileAudioSource(
+                local_filepath,
+                pipeline.config.sample_rate,
+                padding,
+                pipeline.config.step,
+            )
+            pipeline.set_timestamp_shift(-padding[0])
+            inference = StreamingInference(
+                pipeline,
+                source,
+                self.batch_size,
+                do_profile=False,
+                do_plot=False,
+                show_progress=self.show_progress,
+                progress_bar=progress_bar,
+            )
 
-        pred = inference()
-        pred.uri = source.uri
+            pred = inference()
+            pred.uri = source.uri
 
         if self.output_path is not None:
             with open(self.output_path / f"{source.uri}.rttm", "w") as out_file:
@@ -380,8 +397,14 @@ class Benchmark:
             progress_bar = TQDMProgressBar(f"Computing {metric.name}", leave=False)
             progress_bar.create(total=len(predictions), unit="file")
             progress_bar.start()
+            is_remote_ref = storage.is_remote(self.reference_path)
             for hyp in predictions:
-                ref = load_rttm(self.reference_path / f"{hyp.uri}.rttm").popitem()[1]
+                if is_remote_ref:
+                    ref_path = f"{str(self.reference_path).rstrip('/')}/{hyp.uri}.rttm"
+                else:
+                    ref_path = self.reference_path / f"{hyp.uri}.rttm"
+                with storage.localize(ref_path) as local_ref:
+                    ref = load_rttm(local_ref).popitem()[1]
                 metric(ref, hyp)
                 progress_bar.update()
             progress_bar.close()
@@ -423,7 +446,7 @@ class Benchmark:
         predictions = []
         for i, filepath in enumerate(audio_file_paths):
             pipeline.reset()
-            desc = f"Streaming {filepath.stem} ({i + 1}/{num_audio_files})"
+            desc = f"Streaming {storage.get_stem(filepath)} ({i + 1}/{num_audio_files})"
             progress = TQDMProgressBar(desc, leave=False, do_close=True)
             predictions.append(self.run_single(pipeline, filepath, progress))
 
@@ -542,7 +565,7 @@ class Parallelize:
                 pipeline_class,
                 config,
                 filepath,
-                f"Streaming {filepath.stem} ({i + 1}/{num_audio_files})",
+                f"Streaming {storage.get_stem(filepath)} ({i + 1}/{num_audio_files})",
             )
             for i, filepath in enumerate(audio_file_paths)
         ]

--- a/src/diart/optim.py
+++ b/src/diart/optim.py
@@ -12,6 +12,7 @@ from typing_extensions import Literal
 from . import blocks
 from .audio import FilePath
 from .inference import Benchmark
+from .storage import Dataset
 
 
 class Optimizer:
@@ -32,8 +33,7 @@ class Optimizer:
         # FIXME can we run this benchmark in parallel?
         #  Currently it breaks the trial progress bar
         self.benchmark = Benchmark(
-            speech_path,
-            reference_path,
+            Dataset(speech_path, reference_path),
             show_progress=True,
             show_report=False,
             batch_size=batch_size,

--- a/src/diart/optim.py
+++ b/src/diart/optim.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from pathlib import Path
-from typing import Optional, Sequence, Text, Union
+from typing import Optional, Sequence, Union
 
 from optuna import Study, TrialPruned, create_study
 from optuna.samplers import TPESampler
@@ -19,8 +19,7 @@ class Optimizer:
     def __init__(
         self,
         pipeline_class: type,
-        speech_path: Union[Text, Path],
-        reference_path: Union[Text, Path],
+        dataset: Dataset,
         study_or_path: Union[FilePath, Study],
         batch_size: int = 32,
         hparams: Optional[Sequence[blocks.base.HyperParameter]] = None,
@@ -29,11 +28,14 @@ class Optimizer:
         metric: Optional[BaseMetric] = None,
         direction: Literal["minimize", "maximize"] = "minimize",
     ):
+        # Optimization requires a reference to compute the metric being optimized
+        assert dataset.has_reference, "Optimizer requires a dataset with a reference"
+
         self.pipeline_class = pipeline_class
         # FIXME can we run this benchmark in parallel?
         #  Currently it breaks the trial progress bar
         self.benchmark = Benchmark(
-            Dataset(speech_path, reference_path),
+            dataset,
             show_progress=True,
             show_report=False,
             batch_size=batch_size,

--- a/src/diart/sources.py
+++ b/src/diart/sources.py
@@ -81,7 +81,8 @@ class FileAudioSource(AudioSource):
         padding: Tuple[float, float] = (0, 0),
         block_duration: float = 0.5,
     ):
-        super().__init__(Path(file).stem, sample_rate)
+        file = FilePath(file)
+        super().__init__(file.stem, sample_rate)
         self.loader = AudioLoader(self.sample_rate, mono=True)
         self._duration = self.loader.get_duration(file)
         self.file = file

--- a/src/diart/storage.py
+++ b/src/diart/storage.py
@@ -5,13 +5,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator, List, Optional, Union
 
-try:
-    import fsspec
-
-    IS_FSSPEC_AVAILABLE = True
-except ImportError:
-    fsspec = None
-    IS_FSSPEC_AVAILABLE = False
+import fsspec
 
 # Protocols that point to the local filesystem and don't require fsspec.
 LOCAL_PROTOCOLS = (None, "", "file", "local")
@@ -33,15 +27,7 @@ AUDIO_EXTENSIONS = (
 
 def _split_protocol(path: str):
     """Return the ``(protocol, path)`` pair for a path string."""
-    if IS_FSSPEC_AVAILABLE:
-        return fsspec.core.split_protocol(path)
-
-    # Minimal fallback when fsspec is unavailable: detect a leading "scheme://"
-    if "://" in path:
-        protocol, rest = path.split("://", 1)
-        return protocol, rest
-
-    return None, path
+    return fsspec.core.split_protocol(path)
 
 
 class FilePath:
@@ -76,22 +62,8 @@ class FilePath:
 
     @property
     def _fs(self):
-        """The fsspec filesystem backing this (remote) path.
-
-        Raises a helpful error if the required backend isn't installed.
-        """
-        if not IS_FSSPEC_AVAILABLE:
-            raise ImportError(
-                f"Reading from '{self}' requires extra dependencies. "
-                "Install them with: pip install diart[s3]"
-            )
-        try:
-            return fsspec.filesystem(self._protocol)
-        except ImportError as e:
-            raise ImportError(
-                f"Reading from '{self}' requires the '{self._protocol}' fsspec "
-                "backend. Install it with: pip install diart[s3]"
-            ) from e
+        """The fsspec filesystem backing this (remote) path."""
+        return fsspec.filesystem(self._protocol)
 
     @property
     def name(self) -> str:

--- a/src/diart/storage.py
+++ b/src/diart/storage.py
@@ -2,9 +2,8 @@ import os
 import shutil
 import tempfile
 from contextlib import contextmanager
-from typing import Iterator, List
-
-from .audio import FilePath
+from pathlib import Path
+from typing import Iterator, List, Optional, Union
 
 try:
     import fsspec
@@ -17,7 +16,7 @@ except ImportError:
 # Protocols that point to the local filesystem and don't require fsspec.
 LOCAL_PROTOCOLS = (None, "", "file", "local")
 
-# File extensions recognized as audio when listing a remote directory.
+# File extensions recognized as audio when listing a directory.
 AUDIO_EXTENSIONS = (
     ".wav",
     ".flac",
@@ -32,101 +31,197 @@ AUDIO_EXTENSIONS = (
 )
 
 
-def _split_protocol(path: FilePath):
-    """Return the ``(protocol, path)`` pair for a path-like object."""
-    text = str(path)
+def _split_protocol(path: str):
+    """Return the ``(protocol, path)`` pair for a path string."""
     if IS_FSSPEC_AVAILABLE:
-        return fsspec.core.split_protocol(text)
-    # Minimal fallback when fsspec is unavailable: detect a leading "scheme://".
-    if "://" in text:
-        protocol, rest = text.split("://", 1)
+        return fsspec.core.split_protocol(path)
+
+    # Minimal fallback when fsspec is unavailable: detect a leading "scheme://"
+    if "://" in path:
+        protocol, rest = path.split("://", 1)
         return protocol, rest
-    return None, text
+
+    return None, path
 
 
-def is_remote(path: FilePath) -> bool:
-    """Whether `path` points to a remote filesystem (e.g. ``s3://bucket/key``)."""
-    protocol, _ = _split_protocol(path)
-    return protocol not in LOCAL_PROTOCOLS
-
-
-def _require_fsspec(path: FilePath):
-    """Return an fsspec filesystem for `path`, with a helpful error if a remote
-    path is used but the required backend isn't installed."""
-    if not IS_FSSPEC_AVAILABLE:
-        raise ImportError(
-            f"Reading from '{path}' requires extra dependencies. "
-            "Install them with: pip install diart[s3]"
-        )
-    protocol, _ = _split_protocol(path)
-    try:
-        return fsspec.filesystem(protocol)
-    except ImportError as e:
-        raise ImportError(
-            f"Reading from '{path}' requires the '{protocol}' fsspec backend. "
-            "Install it with: pip install diart[s3]"
-        ) from e
-
-
-def get_stem(path: FilePath) -> str:
-    """Return the file name without its extension for local or remote paths.
-
-    Unlike `pathlib.Path`, this is safe for remote URLs whose ``//`` would
-    otherwise be collapsed (e.g. ``s3://bucket/sub/file.wav`` -> ``file``).
-    """
-    name = str(path).rstrip("/").rsplit("/", 1)[-1]
-    stem, _, _ = name.rpartition(".")
-    return stem or name
-
-
-def exists(path: FilePath) -> bool:
-    """Whether a remote path exists (resolves to a directory or object)."""
-    fs = _require_fsspec(path)
-    _, stripped = _split_protocol(path)
-    return fs.exists(stripped)
-
-
-def list_audio_files(path: FilePath) -> List[str]:
-    """List audio files under a remote directory as fully-qualified URLs.
+class FilePath:
+    """A file or directory on a local or remote (fsspec) filesystem.
 
     Parameters
     ----------
-    path: FilePath
-        Remote directory URL (e.g. ``s3://my-bucket/audio``).
-
-    Returns
-    -------
-    urls: List[str]
-        Fully-qualified URLs (protocol included) for each audio file found,
-        sorted for deterministic ordering.
+    path: str, Path or FilePath
+        The path to wrap. Remote URLs keep their protocol; local paths are
+        expanded (``~`` resolution).
     """
-    fs = _require_fsspec(path)
-    _, stripped = _split_protocol(path)
-    entries = fs.ls(stripped, detail=False)
-    audio = [e for e in entries if e.lower().endswith(AUDIO_EXTENSIONS)]
-    # `ls` strips the protocol; re-add it so downstream consumers stay protocol-aware.
-    return sorted(fs.unstrip_protocol(e) for e in audio)
+
+    def __init__(self, path: "PathLike"):
+        if isinstance(path, FilePath):
+            self._protocol = path._protocol
+            self._path = path._path
+            return
+
+        protocol, rest = _split_protocol(str(path))
+        self._protocol = protocol
+        if protocol in LOCAL_PROTOCOLS:
+            # Normalize local path
+            self._path = str(Path(rest).expanduser())
+        else:
+            # Keep remote paths as plain strings (pathlib collapses "//")
+            self._path = rest.rstrip("/")
+
+    @property
+    def is_remote(self) -> bool:
+        """Whether this path points to a remote filesystem."""
+        return self._protocol not in LOCAL_PROTOCOLS
+
+    @property
+    def _fs(self):
+        """The fsspec filesystem backing this (remote) path.
+
+        Raises a helpful error if the required backend isn't installed.
+        """
+        if not IS_FSSPEC_AVAILABLE:
+            raise ImportError(
+                f"Reading from '{self}' requires extra dependencies. "
+                "Install them with: pip install diart[s3]"
+            )
+        try:
+            return fsspec.filesystem(self._protocol)
+        except ImportError as e:
+            raise ImportError(
+                f"Reading from '{self}' requires the '{self._protocol}' fsspec "
+                "backend. Install it with: pip install diart[s3]"
+            ) from e
+
+    @property
+    def name(self) -> str:
+        """The final path component, including any extension."""
+        return self._path.rstrip("/").rsplit("/", 1)[-1]
+
+    @property
+    def stem(self) -> str:
+        """The final path component without its extension."""
+        name = self.name
+        stem, _, _ = name.rpartition(".")
+        return stem or name
+
+    @property
+    def suffix(self) -> str:
+        """The file extension (including the leading dot), or ``""``."""
+        name = self.name
+        _, dot, ext = name.rpartition(".")
+        return f"{dot}{ext}" if dot else ""
+
+    def exists(self) -> bool:
+        """Whether this path exists."""
+        if self.is_remote:
+            return self._fs.exists(self._path)
+        return Path(self._path).exists()
+
+    def is_dir(self) -> bool:
+        """Whether this path is an existing directory."""
+        if self.is_remote:
+            return self._fs.isdir(self._path)
+        return Path(self._path).is_dir()
+
+    def iterdir(self) -> List["FilePath"]:
+        """List the children of this directory as `FilePath` objects."""
+        if self.is_remote:
+            entries = self._fs.ls(self._path, detail=False)
+            return [FilePath(self._fs.unstrip_protocol(e)) for e in entries]
+        return [FilePath(child) for child in Path(self._path).iterdir()]
+
+    def __truediv__(self, name: str) -> "FilePath":
+        child = FilePath(self)
+        child._path = f"{self._path}/{name}"
+        return child
+
+    @contextmanager
+    def localize(self) -> Iterator["FilePath"]:
+        """Yield a local `FilePath` for this path, downloading it if remote.
+
+        Local paths are yielded unchanged (no copy). Remote files are downloaded
+        to a temporary directory, preserving the original base name so the
+        derived URI/stem stays correct, and removed when the context exits.
+        """
+        if not self.is_remote:
+            yield self
+            return
+
+        tmp_dir = tempfile.mkdtemp(prefix="diart-")
+        local_path = os.path.join(tmp_dir, self.name)
+        try:
+            self._fs.get_file(self._path, local_path)
+            yield FilePath(local_path)
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    def __fspath__(self) -> str:
+        if self.is_remote:
+            raise TypeError(f"Remote path '{self}' cannot be used as a local path")
+        return self._path
+
+    def __str__(self) -> str:
+        if self.is_remote:
+            return f"{self._protocol}://{self._path}"
+        return self._path
+
+    def __repr__(self) -> str:
+        return f"FilePath('{self}')"
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, FilePath):
+            return (self._protocol, self._path) == (other._protocol, other._path)
+        if isinstance(other, (str, Path)):
+            return self == FilePath(other)
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash((self._protocol, self._path))
 
 
-@contextmanager
-def localize(path: FilePath) -> Iterator[FilePath]:
-    """Yield a local path for `path`, downloading it first if it is remote.
+# Anything that can be coerced into a `FilePath`.
+PathLike = Union[str, Path, FilePath]
 
-    Local paths are yielded unchanged (no copy). Remote files are downloaded to
-    a temporary directory, preserving the original base name so that the derived
-    URI/stem stays correct, and removed when the context exits.
+
+class Dataset:
+    """A benchmark dataset: a directory of audio files and optional reference RTTMs.
+
+    Parameters
+    ----------
+    audio_path: PathLike
+        Directory with audio files. May be local or a remote URL (e.g. ``s3://``).
+    reference_path: PathLike or None
+        Directory with reference RTTM files whose names match the audio files.
+        Defaults to None.
     """
-    if not is_remote(path):
-        yield path
-        return
 
-    fs = _require_fsspec(path)
-    _, stripped = _split_protocol(path)
-    tmp_dir = tempfile.mkdtemp(prefix="diart-")
-    basename = str(path).rstrip("/").rsplit("/", 1)[-1]
-    local_path = os.path.join(tmp_dir, basename)
-    try:
-        fs.get_file(stripped, local_path)
-        yield local_path
-    finally:
-        shutil.rmtree(tmp_dir, ignore_errors=True)
+    def __init__(
+        self,
+        audio_path: PathLike,
+        reference_path: Optional[PathLike] = None,
+    ):
+        self.speech = FilePath(audio_path)
+        assert self.speech.is_dir(), "Speech path must be a directory"
+
+        self.reference = None
+        if reference_path is not None:
+            self.reference = FilePath(reference_path)
+            assert self.reference.is_dir(), "Reference path must be a directory"
+
+    @property
+    def has_reference(self) -> bool:
+        """Whether reference RTTMs are available for evaluation."""
+        return self.reference is not None
+
+    def audio_files(self) -> List[FilePath]:
+        """Return the audio files in the dataset, sorted for deterministic order."""
+        files = [
+            f for f in self.speech.iterdir() if f.suffix.lower() in AUDIO_EXTENSIONS
+        ]
+        return sorted(files, key=str)
+
+    def reference_for(self, uri: str) -> FilePath:
+        """Return the reference RTTM path matching a given audio URI."""
+        assert self.reference is not None, "This dataset has no reference"
+        return self.reference / f"{uri}.rttm"

--- a/src/diart/storage.py
+++ b/src/diart/storage.py
@@ -1,0 +1,132 @@
+import os
+import shutil
+import tempfile
+from contextlib import contextmanager
+from typing import Iterator, List
+
+from .audio import FilePath
+
+try:
+    import fsspec
+
+    IS_FSSPEC_AVAILABLE = True
+except ImportError:
+    fsspec = None
+    IS_FSSPEC_AVAILABLE = False
+
+# Protocols that point to the local filesystem and don't require fsspec.
+LOCAL_PROTOCOLS = (None, "", "file", "local")
+
+# File extensions recognized as audio when listing a remote directory.
+AUDIO_EXTENSIONS = (
+    ".wav",
+    ".flac",
+    ".m4a",
+    ".mp3",
+    ".ogg",
+    ".opus",
+    ".aac",
+    ".wma",
+    ".aiff",
+    ".aif",
+)
+
+
+def _split_protocol(path: FilePath):
+    """Return the ``(protocol, path)`` pair for a path-like object."""
+    text = str(path)
+    if IS_FSSPEC_AVAILABLE:
+        return fsspec.core.split_protocol(text)
+    # Minimal fallback when fsspec is unavailable: detect a leading "scheme://".
+    if "://" in text:
+        protocol, rest = text.split("://", 1)
+        return protocol, rest
+    return None, text
+
+
+def is_remote(path: FilePath) -> bool:
+    """Whether `path` points to a remote filesystem (e.g. ``s3://bucket/key``)."""
+    protocol, _ = _split_protocol(path)
+    return protocol not in LOCAL_PROTOCOLS
+
+
+def _require_fsspec(path: FilePath):
+    """Return an fsspec filesystem for `path`, with a helpful error if a remote
+    path is used but the required backend isn't installed."""
+    if not IS_FSSPEC_AVAILABLE:
+        raise ImportError(
+            f"Reading from '{path}' requires extra dependencies. "
+            "Install them with: pip install diart[s3]"
+        )
+    protocol, _ = _split_protocol(path)
+    try:
+        return fsspec.filesystem(protocol)
+    except ImportError as e:
+        raise ImportError(
+            f"Reading from '{path}' requires the '{protocol}' fsspec backend. "
+            "Install it with: pip install diart[s3]"
+        ) from e
+
+
+def get_stem(path: FilePath) -> str:
+    """Return the file name without its extension for local or remote paths.
+
+    Unlike `pathlib.Path`, this is safe for remote URLs whose ``//`` would
+    otherwise be collapsed (e.g. ``s3://bucket/sub/file.wav`` -> ``file``).
+    """
+    name = str(path).rstrip("/").rsplit("/", 1)[-1]
+    stem, _, _ = name.rpartition(".")
+    return stem or name
+
+
+def exists(path: FilePath) -> bool:
+    """Whether a remote path exists (resolves to a directory or object)."""
+    fs = _require_fsspec(path)
+    _, stripped = _split_protocol(path)
+    return fs.exists(stripped)
+
+
+def list_audio_files(path: FilePath) -> List[str]:
+    """List audio files under a remote directory as fully-qualified URLs.
+
+    Parameters
+    ----------
+    path: FilePath
+        Remote directory URL (e.g. ``s3://my-bucket/audio``).
+
+    Returns
+    -------
+    urls: List[str]
+        Fully-qualified URLs (protocol included) for each audio file found,
+        sorted for deterministic ordering.
+    """
+    fs = _require_fsspec(path)
+    _, stripped = _split_protocol(path)
+    entries = fs.ls(stripped, detail=False)
+    audio = [e for e in entries if e.lower().endswith(AUDIO_EXTENSIONS)]
+    # `ls` strips the protocol; re-add it so downstream consumers stay protocol-aware.
+    return sorted(fs.unstrip_protocol(e) for e in audio)
+
+
+@contextmanager
+def localize(path: FilePath) -> Iterator[FilePath]:
+    """Yield a local path for `path`, downloading it first if it is remote.
+
+    Local paths are yielded unchanged (no copy). Remote files are downloaded to
+    a temporary directory, preserving the original base name so that the derived
+    URI/stem stays correct, and removed when the context exits.
+    """
+    if not is_remote(path):
+        yield path
+        return
+
+    fs = _require_fsspec(path)
+    _, stripped = _split_protocol(path)
+    tmp_dir = tempfile.mkdtemp(prefix="diart-")
+    basename = str(path).rstrip("/").rsplit("/", 1)[-1]
+    local_path = os.path.join(tmp_dir, basename)
+    try:
+        fs.get_file(stripped, local_path)
+        yield local_path
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,14 @@
 import random
+from pathlib import Path
 
 import pytest
 import torch
 
+from diart import SpeakerDiarizationConfig
 from diart.models import EmbeddingModel, SegmentationModel
+
+MODEL_DIR = Path(__file__).parent.parent / "assets" / "models"
+DATA_DIR = Path(__file__).parent / "data"
 
 
 class DummySegmentationModel:
@@ -46,3 +51,29 @@ def segmentation_model() -> SegmentationModel:
 @pytest.fixture(scope="session")
 def embedding_model() -> EmbeddingModel:
     return EmbeddingModel(DummyEmbeddingModel)
+
+
+@pytest.fixture(scope="session")
+def segmentation() -> SegmentationModel:
+    return SegmentationModel.from_pretrained(MODEL_DIR / "segmentation_uint8.onnx")
+
+
+@pytest.fixture(scope="session")
+def embedding() -> EmbeddingModel:
+    return EmbeddingModel.from_pretrained(MODEL_DIR / "embedding_uint8.onnx")
+
+
+@pytest.fixture(scope="session")
+def make_config(segmentation, embedding):
+    def _config(latency):
+        return SpeakerDiarizationConfig(
+            segmentation=segmentation,
+            embedding=embedding,
+            step=0.5,
+            latency=latency,
+            tau_active=0.507,
+            rho_update=0.006,
+            delta_new=1.057,
+        )
+
+    return _config

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -4,41 +4,11 @@ from pathlib import Path
 import pytest
 from pyannote.database.util import load_rttm
 
-from diart import SpeakerDiarization, SpeakerDiarizationConfig
+from diart import SpeakerDiarization
 from diart.inference import StreamingInference
-from diart.models import EmbeddingModel, SegmentationModel
 from diart.sources import FileAudioSource
 
-MODEL_DIR = Path(__file__).parent.parent / "assets" / "models"
 DATA_DIR = Path(__file__).parent / "data"
-
-
-@pytest.fixture(scope="session")
-def segmentation():
-    model_path = MODEL_DIR / "segmentation_uint8.onnx"
-    return SegmentationModel.from_pretrained(model_path)
-
-
-@pytest.fixture(scope="session")
-def embedding():
-    model_path = MODEL_DIR / "embedding_uint8.onnx"
-    return EmbeddingModel.from_pretrained(model_path)
-
-
-@pytest.fixture(scope="session")
-def make_config(segmentation, embedding):
-    def _config(latency):
-        return SpeakerDiarizationConfig(
-            segmentation=segmentation,
-            embedding=embedding,
-            step=0.5,
-            latency=latency,
-            tau_active=0.507,
-            rho_update=0.006,
-            delta_new=1.057,
-        )
-
-    return _config
 
 
 @pytest.mark.parametrize("source_file", [DATA_DIR / "audio" / "sample.wav"])

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -3,8 +3,9 @@ from pathlib import Path
 import fsspec
 import pandas as pd
 
-from diart import SpeakerDiarization, storage
+from diart import SpeakerDiarization
 from diart.inference import Benchmark
+from diart.storage import Dataset, FilePath
 
 DATA_DIR = Path(__file__).parent / "data"
 
@@ -13,53 +14,96 @@ RTTM_FILE = DATA_DIR / "rttm" / "latency_0.5.rttm"
 
 
 def test_is_remote():
-    assert storage.is_remote("s3://bucket/key")
-    assert storage.is_remote("memory://bench/audio")
-    assert not storage.is_remote("/tmp/audio")
-    assert not storage.is_remote("file:///tmp/audio")
-    assert not storage.is_remote(Path("/tmp/audio"))
+    assert FilePath("s3://bucket/key").is_remote
+    assert FilePath("memory://bench/audio").is_remote
+    assert not FilePath("/tmp/audio").is_remote
+    assert not FilePath("file:///tmp/audio").is_remote
+    assert not FilePath(Path("/tmp/audio")).is_remote
 
 
-def test_get_stem():
-    assert storage.get_stem("s3://bucket/sub/file.wav") == "file"
-    assert storage.get_stem("memory://x/y.rttm") == "y"
-    assert storage.get_stem(Path("/tmp/a/file.flac")) == "file"
-    assert storage.get_stem("s3://bucket/audio/") == "audio"
+def test_stem_name_suffix():
+    remote = FilePath("s3://bucket/sub/file.wav")
+    assert remote.stem == "file"
+    assert remote.name == "file.wav"
+    assert remote.suffix == ".wav"
+
+    assert FilePath("memory://x/y.rttm").stem == "y"
+    assert FilePath(Path("/tmp/a/file.flac")).stem == "file"
+    # A trailing slash (e.g. a directory) yields the last component as the stem
+    assert FilePath("s3://bucket/audio/").stem == "audio"
+
+
+def test_str_roundtrips_protocol():
+    assert str(FilePath("s3://bucket/sub/file.wav")) == "s3://bucket/sub/file.wav"
+    # Remote paths keep their double slash (pathlib would collapse it)
+    assert FilePath("s3://bucket/x.wav") == FilePath("s3://bucket/x.wav")
+
+
+def test_truediv_joins_for_local_and_remote():
+    assert FilePath("s3://bucket/rttm") / "conv.rttm" == FilePath(
+        "s3://bucket/rttm/conv.rttm"
+    )
+    assert FilePath("/data/rttm") / "conv.rttm" == FilePath("/data/rttm/conv.rttm")
 
 
 def test_localize_local_path_is_not_copied():
-    with storage.localize(AUDIO_FILE) as local:
-        assert local == AUDIO_FILE
+    local = FilePath(AUDIO_FILE)
+    with local.localize() as localized:
+        # Local paths are yielded unchanged (no copy)
+        assert localized == local
+        assert localized is local
 
 
 def test_localize_remote_downloads_and_cleans_up():
     fs = fsspec.filesystem("memory")
     fs.pipe_file("loc/sample.wav", AUDIO_FILE.read_bytes())
 
-    with storage.localize("memory://loc/sample.wav") as local:
-        local = Path(local)
+    with FilePath("memory://loc/sample.wav").localize() as local:
+        assert not local.is_remote
         # Base name is preserved so the derived URI/stem stays correct
         assert local.name == "sample.wav"
-        assert local.exists()
-        assert local.read_bytes() == AUDIO_FILE.read_bytes()
-        tmp_dir = local.parent
+        path = Path(local)
+        assert path.exists()
+        assert path.read_bytes() == AUDIO_FILE.read_bytes()
+        tmp_dir = path.parent
 
     # The temporary copy is removed on context exit
     assert not tmp_dir.exists()
 
 
-def test_list_audio_files_filters_and_qualifies():
+def test_dataset_audio_files_filters_and_qualifies():
     fs = fsspec.filesystem("memory")
-    fs.pipe_file("lst/sample.wav", AUDIO_FILE.read_bytes())
-    fs.pipe_file("lst/other.flac", b"not really audio")
-    fs.pipe_file("lst/notes.txt", b"ignore me")
+    fs.pipe_file("ds/audio/sample.wav", AUDIO_FILE.read_bytes())
+    fs.pipe_file("ds/audio/other.flac", b"not really audio")
+    fs.pipe_file("ds/audio/notes.txt", b"ignore me")
+    fs.pipe_file("ds/rttm/sample.rttm", RTTM_FILE.read_bytes())
 
-    files = storage.list_audio_files("memory://lst")
+    dataset = Dataset("memory://ds/audio", "memory://ds/rttm")
+    files = dataset.audio_files()
 
-    # Only audio files are returned, each as a fully-qualified (remote) URL
-    assert len(files) == 2
-    assert all(storage.is_remote(f) for f in files)
-    assert sorted(storage.get_stem(f) for f in files) == ["other", "sample"]
+    # Only audio files are returned, each as a fully-qualified remote FilePath
+    assert all(isinstance(f, FilePath) and f.is_remote for f in files)
+    assert [f.stem for f in files] == ["other", "sample"]  # sorted
+
+
+def test_dataset_reference_for():
+    fs = fsspec.filesystem("memory")
+    fs.pipe_file("refds/audio/sample.wav", AUDIO_FILE.read_bytes())
+    fs.pipe_file("refds/rttm/sample.rttm", RTTM_FILE.read_bytes())
+
+    dataset = Dataset("memory://refds/audio", "memory://refds/rttm")
+    assert dataset.has_reference
+    assert dataset.reference_for("sample") == FilePath(
+        "memory://refds/rttm/sample.rttm"
+    )
+
+
+def test_dataset_without_reference():
+    fs = fsspec.filesystem("memory")
+    fs.pipe_file("noref/audio/sample.wav", AUDIO_FILE.read_bytes())
+
+    dataset = Dataset("memory://noref/audio")
+    assert not dataset.has_reference
 
 
 def _populate_memory(prefix: str):
@@ -70,8 +114,7 @@ def _populate_memory(prefix: str):
 
 def _run_benchmark(speech_path, reference_path, make_config):
     benchmark = Benchmark(
-        speech_path,
-        reference_path,
+        Dataset(speech_path, reference_path),
         show_report=False,
     )
     return benchmark(SpeakerDiarization, make_config(0.5))

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+
+import fsspec
+import pandas as pd
+
+from diart import SpeakerDiarization, storage
+from diart.inference import Benchmark
+
+DATA_DIR = Path(__file__).parent / "data"
+
+AUDIO_FILE = DATA_DIR / "audio" / "sample.wav"
+RTTM_FILE = DATA_DIR / "rttm" / "latency_0.5.rttm"
+
+
+def test_is_remote():
+    assert storage.is_remote("s3://bucket/key")
+    assert storage.is_remote("memory://bench/audio")
+    assert not storage.is_remote("/tmp/audio")
+    assert not storage.is_remote("file:///tmp/audio")
+    assert not storage.is_remote(Path("/tmp/audio"))
+
+
+def test_get_stem():
+    assert storage.get_stem("s3://bucket/sub/file.wav") == "file"
+    assert storage.get_stem("memory://x/y.rttm") == "y"
+    assert storage.get_stem(Path("/tmp/a/file.flac")) == "file"
+    assert storage.get_stem("s3://bucket/audio/") == "audio"
+
+
+def test_localize_local_path_is_not_copied():
+    with storage.localize(AUDIO_FILE) as local:
+        assert local == AUDIO_FILE
+
+
+def test_localize_remote_downloads_and_cleans_up():
+    fs = fsspec.filesystem("memory")
+    fs.pipe_file("loc/sample.wav", AUDIO_FILE.read_bytes())
+
+    with storage.localize("memory://loc/sample.wav") as local:
+        local = Path(local)
+        # Base name is preserved so the derived URI/stem stays correct
+        assert local.name == "sample.wav"
+        assert local.exists()
+        assert local.read_bytes() == AUDIO_FILE.read_bytes()
+        tmp_dir = local.parent
+
+    # The temporary copy is removed on context exit
+    assert not tmp_dir.exists()
+
+
+def test_list_audio_files_filters_and_qualifies():
+    fs = fsspec.filesystem("memory")
+    fs.pipe_file("lst/sample.wav", AUDIO_FILE.read_bytes())
+    fs.pipe_file("lst/other.flac", b"not really audio")
+    fs.pipe_file("lst/notes.txt", b"ignore me")
+
+    files = storage.list_audio_files("memory://lst")
+
+    # Only audio files are returned, each as a fully-qualified (remote) URL
+    assert len(files) == 2
+    assert all(storage.is_remote(f) for f in files)
+    assert sorted(storage.get_stem(f) for f in files) == ["other", "sample"]
+
+
+def _populate_memory(prefix: str):
+    fs = fsspec.filesystem("memory")
+    fs.pipe_file(f"{prefix}/audio/sample.wav", AUDIO_FILE.read_bytes())
+    fs.pipe_file(f"{prefix}/rttm/sample.rttm", RTTM_FILE.read_bytes())
+
+
+def _run_benchmark(speech_path, reference_path, make_config):
+    benchmark = Benchmark(
+        speech_path,
+        reference_path,
+        show_report=False,
+    )
+    return benchmark(SpeakerDiarization, make_config(0.5))
+
+
+def test_benchmark_over_memory_matches_local(make_config, tmp_path):
+    # Local reference layout: matching audio and rttm stems
+    (tmp_path / "audio").mkdir()
+    (tmp_path / "rttm").mkdir()
+    (tmp_path / "audio" / "sample.wav").write_bytes(AUDIO_FILE.read_bytes())
+    (tmp_path / "rttm" / "sample.rttm").write_bytes(RTTM_FILE.read_bytes())
+
+    _populate_memory("bench")
+
+    local_report = _run_benchmark(tmp_path / "audio", tmp_path / "rttm", make_config)
+    remote_report = _run_benchmark(
+        "memory://bench/audio", "memory://bench/rttm", make_config
+    )
+
+    assert isinstance(remote_report, pd.DataFrame)
+    pd.testing.assert_frame_equal(remote_report, local_report)

--- a/uv.lock
+++ b/uv.lock
@@ -838,6 +838,7 @@ name = "diart"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },
+    { name = "fsspec" },
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -853,6 +854,7 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "rx" },
+    { name = "s3fs" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -878,9 +880,6 @@ onnx = [
     { name = "onnxruntime", version = "1.24.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-s3 = [
-    { name = "s3fs" },
-]
 
 [package.dev-dependencies]
 dev = [
@@ -892,6 +891,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "einops", specifier = ">=0.7.0" },
+    { name = "fsspec", specifier = ">=2024.0.0" },
     { name = "furo", marker = "extra == 'docs'", specifier = ">=2024.1.29" },
     { name = "matplotlib", specifier = ">=3.8.0,<4.0.0" },
     { name = "numpy", specifier = ">=2.0.0" },
@@ -906,7 +906,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.31.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "rx", specifier = ">=3.2.0" },
-    { name = "s3fs", marker = "extra == 's3'", specifier = ">=2024.0.0" },
+    { name = "s3fs", specifier = ">=2024.0.0" },
     { name = "scipy", specifier = ">=1.11.0" },
     { name = "sounddevice", specifier = ">=0.5.0" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7.0.0" },
@@ -919,7 +919,7 @@ requires-dist = [
     { name = "websocket-client", specifier = ">=1.7.0" },
     { name = "websocket-server", specifier = ">=0.6.4" },
 ]
-provides-extras = ["docs", "onnx", "s3"]
+provides-extras = ["docs", "onnx"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -30,6 +30,25 @@ wheels = [
 ]
 
 [[package]]
+name = "aiobotocore"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aioitertools" },
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "multidict" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/75/42cce839c2ec263ff74b10b650fe36b066fbb124cbee6f247eac0983e1ab/aiobotocore-3.7.0.tar.gz", hash = "sha256:c64d871ed5491a6571948dd48eabd185b46c6c23b64e3afd0c059fc7593ada30", size = 127054, upload-time = "2026-05-09T10:02:52.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/5f/85535dfb3cfd6442d66d1df1694062c5d6df02f895329e7e120b2a3d2b8b/aiobotocore-3.7.0-py3-none-any.whl", hash = "sha256:680bde7c64679a821a9312641b759d9497f790ba8b2e88c6959e6273ee765b8e", size = 89539, upload-time = "2026-05-09T10:02:50.389Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -176,6 +195,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aioitertools"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/3c/53c4a17a05fb9ea2313ee1777ff53f5e001aefd5cc85aa2f4c2d982e1e38/aioitertools-0.13.0.tar.gz", hash = "sha256:620bd241acc0bbb9ec819f1ab215866871b4bbd1f73836a55f799200ee86950c", size = 19322, upload-time = "2025-11-06T22:17:07.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl", hash = "sha256:0be0292b856f08dfac90e31f4739432f4cb6d7520ab9eb73e143f4f2fa5259be", size = 24182, upload-time = "2025-11-06T22:17:06.502Z" },
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -306,6 +334,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/79/2f4be1896db3db7ccf44504253a175d56b6bd6b669619edc5147d1aa21ea/botocore-1.43.0.tar.gz", hash = "sha256:e933b31a2d644253e1d029d7d39e99ba41b87e29300534f189744cc438cdf928", size = 15286817, upload-time = "2026-04-29T22:07:31.723Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/4b/afc1fef8a43bafb139f57f73bbd70df82807af5934321e8112ae50668827/botocore-1.43.0-py3-none-any.whl", hash = "sha256:cc5b15eaec3c6eac05d8012cb5ef17ebe891beb88a16ca13c374bfaece1241e6", size = 14970102, upload-time = "2026-04-29T22:07:27Z" },
 ]
 
 [[package]]
@@ -836,6 +878,9 @@ onnx = [
     { name = "onnxruntime", version = "1.24.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
+s3 = [
+    { name = "s3fs" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -861,6 +906,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.31.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "rx", specifier = ">=3.2.0" },
+    { name = "s3fs", marker = "extra == 's3'", specifier = ">=2024.0.0" },
     { name = "scipy", specifier = ">=1.11.0" },
     { name = "sounddevice", specifier = ">=0.5.0" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7.0.0" },
@@ -873,7 +919,7 @@ requires-dist = [
     { name = "websocket-client", specifier = ">=1.7.0" },
     { name = "websocket-server", specifier = ">=0.6.4" },
 ]
-provides-extras = ["docs", "onnx"]
+provides-extras = ["docs", "onnx", "s3"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1469,6 +1515,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -3476,6 +3531,20 @@ wheels = [
 ]
 
 [[package]]
+name = "s3fs"
+version = "2026.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiobotocore" },
+    { name = "aiohttp" },
+    { name = "fsspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/00/6677343dc919d6c072bb04d80210afdd22c16838a8d16b3315c122dc728f/s3fs-2026.6.0.tar.gz", hash = "sha256:b28de7082d0a4f72392884bdc497e34a4a1582f675d214c7da0acf6e950a0083", size = 87358, upload-time = "2026-06-16T02:05:48.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/0b/f68a968b49876eae0f2a515387093cebb2eb9451380a96741cc20efac0d0/s3fs-2026.6.0-py3-none-any.whl", hash = "sha256:60576e31bb31193c1f643f32b4c6439548720ea6918ac702e21cd757c80b5db8", size = 32573, upload-time = "2026-06-16T02:05:47.608Z" },
+]
+
+[[package]]
 name = "safetensors"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4475,6 +4544,92 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/80/19/1587bc8033debcb42d8176ca93cc44c8c874a043a1a8513e4890ad6447fb/websocket_server-0.6.4.tar.gz", hash = "sha256:a8a02d575905e50f6af90bbbc37d23d7e1b027630897f0eeefed6a3fb3c22e07", size = 8696, upload-time = "2021-12-19T16:34:35.826Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/9e/510086a9ed0dee3830da838f9207f5c787487813d5eb74eb19fe306e6a3e/websocket_server-0.6.4-py3-none-any.whl", hash = "sha256:aca2d8f7569c82fe3e949cbae1f9d3f3035ae15f1d4048085431c94b7dfd35be", size = 7534, upload-time = "2021-12-19T16:34:34.597Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/9f/06263fcd8ad6c405f05a3905fd7a84dd3176eb5ad46e44bccc0cd16348bb/wrapt-2.2.1.tar.gz", hash = "sha256:6744f504375775d7609c82c8d3d94af1c9a6f05586984536905908ba905277b9", size = 127620, upload-time = "2026-05-22T14:49:43.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/8b/84bc1ea68b620fe0e2696a8cff07e82f4b962d952ab14efee8955997bb70/wrapt-2.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0f68f478004475d97906686e702ddbddeaf717c0b68ad2794384308f2dc713ae", size = 80093, upload-time = "2026-05-22T14:47:27.074Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/8f/64ec81194a0bc708d9720174c998c8a32116e82b5b32c04e20a7fe01176c/wrapt-2.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e422b2d647a65d6b080cad5accd09055d3809bdff00c76fba8dca00ca935572a", size = 81183, upload-time = "2026-05-22T14:47:29.062Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/3d186944aae923631d1def58f4c4ff8f0b6309906afc0b6978de3e69b3e0/wrapt-2.2.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:036dfb40128819a751c6f451c6b9c10172c49e4c401aebcdb8ecf2aec1683598", size = 152494, upload-time = "2026-05-22T14:47:30.583Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d1/6b3d0ea995b867d2862aad5619bd5e17de09a9d64a821f46832dcd272d40/wrapt-2.2.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09ac16c081bebfd15d8e4dfa5bdc805990bbd52249ecff22530da7a129d6120b", size = 154310, upload-time = "2026-05-22T14:47:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/4b/37ecb90a8c3753e580327fb40731a984b754e3df65d2ef932bf359fe4adc/wrapt-2.2.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07be671fa8875971222b0ba9059ed8b4dc738631122feba17c93aa36b4213e9a", size = 149002, upload-time = "2026-05-22T14:47:34.021Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/d0/918884d9dfa84d0d135b42a51c00910f5c5447fe7a5e211a8e16ac324dd4/wrapt-2.2.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:93fc2bf40cd7f4a0256010dce073d44eeb4a351b9bca94d0477ce2b6e62532b3", size = 153185, upload-time = "2026-05-22T14:47:35.722Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/00/382299d8ced610b29b59b099a89eda821e8c489aa152b7183748ac83f32a/wrapt-2.2.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:ba519b2d765df9871a25879e6f7fa78948ea59a2a31f9c1a257e34b651994afc", size = 148040, upload-time = "2026-05-22T14:47:37.052Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/46/62a79b79e35bbebb1207ca5d15b81192f37f20cc5659cf4e3ce955b7fcc8/wrapt-2.2.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9011395be8db1827d106c6449b4bb6dd17e331ff6ec521f227e4588f1c78e46f", size = 151773, upload-time = "2026-05-22T14:47:38.713Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/db/95c152151d206d4b430516c89725306e92484072f38e65492afde63f6d19/wrapt-2.2.1-cp310-cp310-win32.whl", hash = "sha256:a8f7176b83664af44567e9cc06e0d3827823fcc1a5e52307ebb8ac3aa95860b9", size = 77393, upload-time = "2026-05-22T14:47:40.061Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/882d50452c6fbd13f24fe5d2644b97cdad2565a7e1522cbb6312de8a52cf/wrapt-2.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:d7f513d3185e6fec82d0c3518f2e6365d8b4e49f5f45f29640d5162d56a23b54", size = 80350, upload-time = "2026-05-22T14:47:41.194Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0f/148376523b4e370692286a9ba14d5715cf3c5b86da3bd3630926367b6b73/wrapt-2.2.1-cp310-cp310-win_arm64.whl", hash = "sha256:44255c84bc57554fed822e83e70036b51afa9edb56fc7ca56c54410ece7898c9", size = 79149, upload-time = "2026-05-22T14:47:42.835Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ac/4370bde262c0e633e6c4f0e56d55095710024cf9a5cecc20c59a10de483c/wrapt-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:dd57607acc85678925940bd5df0385ff8332083a32fa8d7a43f8767f4997263c", size = 80321, upload-time = "2026-05-22T14:47:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/79/b8ff3a61e71babf58a8cf4c0d63358e8bad383e15bf7f35e62d2f6b6e4a4/wrapt-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1ae574d65c9fa8e86f64f6a7c2668f9fcd507b183e0e577619f504b883cb0a6c", size = 81216, upload-time = "2026-05-22T14:47:45.243Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fd/c0cac1f77c9c4f6fe58a920ca632ce379bb8be928720e11e8d73de28a5e9/wrapt-2.2.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9a04c28c10ba7fd12842b109d2edb0678872a2fe65277ca4ff06a0d61edee245", size = 159208, upload-time = "2026-05-22T14:47:47.176Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/4f/744132a7b2fbefa6b81118ec5942eca5fc2e9a129f9055a0c5e46885a549/wrapt-2.2.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3e2f02472a1cbbf3884b365714a810b5947134a95ad6952b554cb8cce9d492b0", size = 160322, upload-time = "2026-05-22T14:47:49.04Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/95/b7cd9a22a06cf93e6482904ee6afc956248983553593fd1009296d1b3b31/wrapt-2.2.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac2745950b2bff80219c15ebf2fa9d8427eba7e249739f97e55c9d169e47e9e1", size = 153243, upload-time = "2026-05-22T14:47:50.386Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4a/eb79423192015f46f0db2872e7e04a3dde8d359b83411e8959e7c9287eaa/wrapt-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67a97e5b6c457f0cd3cfc19ebb2d84463e60c3ece754cc831e4281a3ca29bb18", size = 159231, upload-time = "2026-05-22T14:47:51.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/dc/435015b58ce33c6fc4104158fa91ddb0e809ab03a5751fb7465d1d461456/wrapt-2.2.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:c803a3d331796255af51ba2c79ed0ac8275865b516c09e61f248d1e7aff31ce9", size = 152351, upload-time = "2026-05-22T14:47:53.214Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ac/5d203f98df8fd136b95c5227139aea02d34505e18baf812d0c005df61963/wrapt-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9b984d1eb252145d6302c1dbd5e87fc6d404d45531447c84eadec04bf1fcb027", size = 158347, upload-time = "2026-05-22T14:47:54.982Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2f/a92427dbdc74e54c1674abbed27e61b2cb5e7a94441b8c1270c70671d928/wrapt-2.2.1-cp311-cp311-win32.whl", hash = "sha256:8a983a603a18c8708f024f7f6991b2e66159219abbf894634c5056243c55f3cd", size = 77562, upload-time = "2026-05-22T14:47:56.275Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/56/987b9c13b3e1c1a3c6de71284076f996b79caec90e75a87c044a40c23db9/wrapt-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:9c210a6994b21aa9b29e81c8d11560e8fdab54c117e9cff37870d0a27bde1343", size = 80616, upload-time = "2026-05-22T14:47:57.854Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/25/d01f560888d99d94a959c85533de349ce68d71ace3f2591d6ea8f632cfed/wrapt-2.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:401229e9d63ca09f9b8891ecf83798d26c11bbb445d11ed9f1836b6d4585b38a", size = 79025, upload-time = "2026-05-22T14:47:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/89/0c/bfae7b9401583b6d05938cd16dedc43857d96da2f8a3d50d78cc515bf6ff/wrapt-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3ffad790d9d11d8ecf9f17c4bb671a5b4089e4d8b575c46c5129597f41f836b0", size = 81021, upload-time = "2026-05-22T14:48:00.313Z" },
+    { url = "https://files.pythonhosted.org/packages/26/58/80f6a6599f933f4caecc1cb3ee88a04faf81e8b9bddbd6109c688dd63e0f/wrapt-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:628f5220c7a904d5fc78f7075c8d7871433eb6d035c94728a22fdf85f193d2a8", size = 81692, upload-time = "2026-05-22T14:48:01.49Z" },
+    { url = "https://files.pythonhosted.org/packages/17/93/fb357cc7847c58a8ae790be718903afa81a28d23e642c843dc4129e8a0b2/wrapt-2.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:61acce4257a9883669703c525447c5b4c392edf0f987ae77ec32668440158f0e", size = 169364, upload-time = "2026-05-22T14:48:02.791Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/0b/76b601ee309a8bd556af0eecb184394c20b3c49aa9c8e085aa1ffacc2568/wrapt-2.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:727ab4244622cd6ad2390f322642090c877d2e83a608d2653a7643ae5368d926", size = 171079, upload-time = "2026-05-22T14:48:04.22Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/87/ee3f32d5658e3e26d3e0e457922b47a36dd3bfbdfee7f97bb3e802344a66/wrapt-2.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:03df9ebed4c73ab93fa8c07e3d41d818dfca1852b15731a3de59457b27814624", size = 160205, upload-time = "2026-05-22T14:48:05.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/d0/ae2fd64277a67f5d7bffcf2d05eea1e476263fb2a072baf0b0129ab85984/wrapt-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0d9ff006f420b2ec8296aa56ade43ea7da3e997e85769f0aafc5e0661aacb710", size = 168922, upload-time = "2026-05-22T14:48:07.132Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f3/2d541a060c5bbafb9400bca4917e4d78bfd1f239f404782c86831a8f6b29/wrapt-2.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:844c858fc3bb7eacc0ba8efa904935d16aac6a4470948ad1e7e55c9f5a2a665f", size = 158388, upload-time = "2026-05-22T14:48:08.629Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/68/8d92c8800c57e93cb116ae9e9d6cbafc34fade5ee9f9107b6f203fb4dc35/wrapt-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87bacdaf225117a342a20d9c03438d701c02112f6e3f351ce9b7f32354f14797", size = 167682, upload-time = "2026-05-22T14:48:10.042Z" },
+    { url = "https://files.pythonhosted.org/packages/30/72/83ea3790ea352439442349388e29ff07b76e0686265f9088bbb505d1608d/wrapt-2.2.1-cp312-cp312-win32.whl", hash = "sha256:2f8c90c8afde51969487be4e1343ae049b268854877d415c2510baf833775052", size = 77857, upload-time = "2026-05-22T14:48:11.782Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/cb/99450668dd3502d62a54a1c8aa56e44f34cb8c1261b381cfe2e7926c3b75/wrapt-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ce32763ac31ce94fe9aada947e479b1975012bff166da409b4b9e4e376cf7e5", size = 80825, upload-time = "2026-05-22T14:48:13.046Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3a/87512881be64e743f9ee4c66f4cbe8e884974bef2a5989af71f999653ac7/wrapt-2.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:8d1b4d0e0c2119587a31f5c029abd547e0c81d93b89d394566fe1588659eb579", size = 79087, upload-time = "2026-05-22T14:48:14.323Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/a1b08f8f4fac8cbb156fa51cf64ee2c7f7f74f9875ba3cf70b3c58368694/wrapt-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d2beb1c7cab10603aecdc42f8edd6ff013f9a32e4543474e38e6b77ce9975aeb", size = 80831, upload-time = "2026-05-22T14:48:15.598Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ce/57890814991446a845e09b3445ce8b694f27eb0577004f2c2a36a9772ed4/wrapt-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e0cb7e4dd71f4c32e5e84843cd3c4cd65dda034314004bbe1d7f99af2426ab80", size = 81375, upload-time = "2026-05-22T14:48:17.071Z" },
+    { url = "https://files.pythonhosted.org/packages/38/65/08d7a6c76ac4493bdb668205ee9c1de1bd5daca61717c3e9aa49b4c01499/wrapt-2.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95821352042722cd9f1108874579a47989d0a7e12a37d87d2fc4af20fd99ab8a", size = 167417, upload-time = "2026-05-22T14:48:18.303Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ce/f1ccbee7a1bfe5cdc6b3da6bab4b45713d628b9294da32a39f563d648140/wrapt-2.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abd621552ede77c4c69be7fac44ba911225b0c812b6ba604e5964cf98085b474", size = 166948, upload-time = "2026-05-22T14:48:19.768Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2a/f85d48d1cd4869aee6704028d257d740a47c1c467b457ce396b4b5b55d07/wrapt-2.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e3677c7146ce694874941ba82b57092cc4875445aadf29d72807351023105143", size = 158148, upload-time = "2026-05-22T14:48:21.96Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/5c/93939ad11d4a12358ab1aab219a2ef5efa5612e0db6b9fc65af8af1a891b/wrapt-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9a5934eaea872e17936b5f45501eba5ab0bce9a74122e172b663d7c28c459c4a", size = 165905, upload-time = "2026-05-22T14:48:23.373Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/b8c2aa89862ff58605934d7abf4b70e6a5a1c33df96656f49035ccdf1c8a/wrapt-2.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f5b9daf6b629fce418e0cc3dd0436eac045188fa35deadb7a7f3941d5b8203f9", size = 156712, upload-time = "2026-05-22T14:48:24.767Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/bf00a7b02239c12bb02ddcc3c0b971bfcc36e578c5a44f1ccfef5b458545/wrapt-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f53ac9f3ef573326d009ed809beff4efcac6451931c2b8132586da4b9e53ff31", size = 166560, upload-time = "2026-05-22T14:48:26.83Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/93/6390ca9c5b787683cef588d04f57c8d41b9a2323b5597a65f18638c90ef2/wrapt-2.2.1-cp313-cp313-win32.whl", hash = "sha256:1ffa9cfd4bdb581539951b14ae661ff20ed0c3599b3e911a131ee0ec5ac11337", size = 77817, upload-time = "2026-05-22T14:48:28.221Z" },
+    { url = "https://files.pythonhosted.org/packages/97/73/ce10f0e71c0cfaa1a65faadb8efd4852028b3bb9ba28932b8889df769d38/wrapt-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:368eac1e20fd0bb03dd3cc42bf9887154c3861b60989389ccb5fac032617d215", size = 80736, upload-time = "2026-05-22T14:48:30.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/4c/89f4a6818fafbbd840330e4fa3873073e1bfc166133a64cac7f8fde7a5e3/wrapt-2.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:c754dafdf5aaf0b401b644a90a30046929a0dd1a536e0ff0ec959a59155d9c7f", size = 79099, upload-time = "2026-05-22T14:48:31.405Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f2/9a8741c46f8c208ac0a45b25ba170bcb4fb72a2781d5fb97dbd7b6be73cb/wrapt-2.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ed928d0fda15fc0adc8d13305c8b3c0f2fba5b0669950c9e6d019d9162a3b3e8", size = 82802, upload-time = "2026-05-22T14:48:33.307Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0d/e9c855716a3705eef1416456bdf062b60620726fdc59428ff670fc3c60dc/wrapt-2.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fafb4e739e43544d12cb4abd1605fd4683b6ca6a9ad682b7fd8f4d21973eafa8", size = 83329, upload-time = "2026-05-22T14:48:34.593Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d6/a88f1c13112b7831adac75cea65d8310e0d696d570c8961844c90a57b865/wrapt-2.2.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:74d6a0c31472fe5d814917266b9f46495d7c61ed890af08b468acea92fb89a8d", size = 202937, upload-time = "2026-05-22T14:48:35.859Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/e29d54aef06a4d898a5b8a25589a0b3769bde454f922fad8f6f89fbfb650/wrapt-2.2.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab5be648d5a0b86b7438864f8df3c705a65cef35a2fd3e5561e3e203167e0f27", size = 209997, upload-time = "2026-05-22T14:48:38.153Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/91/e4454263516cf0e12640912fbca9a83654e424f0a6ddb79f5cd7ce14bf33/wrapt-2.2.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d8f204c8e3a8bf9ece17e0a83d137fd807440977f8a5e762d59306795011440", size = 194856, upload-time = "2026-05-22T14:48:39.69Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d0/fe0ee202286afdf4a7f77dd29f195703145764d572aec209c5086e57d924/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d047f6498c973874ba08ac3f97c69a2c4b2211c8de6f4c205f75cb1c9522596e", size = 205654, upload-time = "2026-05-22T14:48:43.456Z" },
+    { url = "https://files.pythonhosted.org/packages/23/b6/87d860dfc6460c246af70b1fd5c8b76df77571b42a493459423ded94fd7d/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:7a4fdb9326aab4a5a477a1640e5ad786a8495901009d7e7b038371edd23a9d2b", size = 192206, upload-time = "2026-05-22T14:48:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/df/46/3eea8cde077d985f239a38c0257087b8064fd9ee9b1a99e282d2c86da4ef/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c8cc5094b08abeae52da9c73c8a32003623be691a5193df2f4e3eac3d557c394", size = 198428, upload-time = "2026-05-22T14:48:46.319Z" },
+    { url = "https://files.pythonhosted.org/packages/18/dc/b927ee9c7fc67adc3a5658f246a0d275425eb840ba36e7b702e70f18bde8/wrapt-2.2.1-cp313-cp313t-win32.whl", hash = "sha256:9907a4402ab6db12b7077a0ea5d7a4d028ecb22c8eee2b53527080d347cd1562", size = 79448, upload-time = "2026-05-22T14:48:47.901Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b3/fd30b473fe498c70e6b9a5f328b8d3fbaf1b8c3c481465f59724bba8eb70/wrapt-2.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:5590d63f5243251641cf543009b4c9314a79d0598fdb8a8e4cfc918494536c53", size = 83021, upload-time = "2026-05-22T14:48:49.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/96c39153a8737a6e9aa85adef254ac4195bea3f2d24efc60472ccc3c9e2e/wrapt-2.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:c318a64b53d97b841d7b5e637517e50a27be64bc695128422953d4b21710954e", size = 80295, upload-time = "2026-05-22T14:48:50.479Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a3/11d7f34ebbf3231bc907a3e6d5ee051b14d034c1bc7b65a97d5cc00516df/wrapt-2.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f56a647e4eaf5f0ca40330fb070f566bdf9f7b0db89a1af20d71c28dcd7a0ab", size = 80879, upload-time = "2026-05-22T14:48:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3c/b74cfd984cef560b900fb1a727af20352d89e1f06bf2e1114dd3f00f5f5a/wrapt-2.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:64b7deeda4b70408e382328d8bbe52a256fe9bc63ae3db86d804608367e5422c", size = 81462, upload-time = "2026-05-22T14:48:53.18Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a3/7c8f704b8dc07dfe0a5d01c2edbfd88317aa8e5e3fa7c743eb7a085ae767/wrapt-2.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9cf53ba90717db2e292401de290776c498d4bbfb0d4a559ca2895db8b9dcb5c", size = 167251, upload-time = "2026-05-22T14:48:54.562Z" },
+    { url = "https://files.pythonhosted.org/packages/80/85/a34d1888d97247da6c2ff6118c3a721c73ed8cc4dd198c00208bb73b6f80/wrapt-2.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf3638274ab9d9b724c9baa0b4c04e132cd6faefb78b4dd3dd1a02a4bdaad41e", size = 166316, upload-time = "2026-05-22T14:48:56.065Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d7/72ffaeb01eebc704afe3fb99e840480f4bda45f0fa66e3381b6a39251c8f/wrapt-2.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aed9658797d0b45d6c49adcfc6b41f66e6f2d0c6de3ec79e16cf4b1855df240f", size = 157952, upload-time = "2026-05-22T14:48:57.924Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5b/36f5d6b024e4edfdd90b140742d11ebcf7836daf5c9daf326c55c24db412/wrapt-2.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1d676ee388bc42a04d56dd7deb5605244dac2e35cc2fadbb43c9fa25bbd93508", size = 166130, upload-time = "2026-05-22T14:48:59.384Z" },
+    { url = "https://files.pythonhosted.org/packages/81/06/9296d9e97bfdef5483dfcc859d57b095b257144b2bc5300ab521e06f4bc7/wrapt-2.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e395f7bc31851ef9b612050368cb446e9bc14cd7454b025018980349caf25ae5", size = 156604, upload-time = "2026-05-22T14:49:00.921Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/16953929ed6776175720e58fc966e779926d8d71e2c7b2273230590ca71f/wrapt-2.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f1845c2a8cc1180ccccfa45785dd06f562730d19ef75be180334254012b6283", size = 166007, upload-time = "2026-05-22T14:49:02.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/73/20ee58c0612dae7c31131a7095345812ed2c7b389019e175f68cde34e5b4/wrapt-2.2.1-cp314-cp314-win32.whl", hash = "sha256:436addbc4bb4fc0a88c702577f51195d7d73683a7f3e0e5b253d8404d7847243", size = 78327, upload-time = "2026-05-22T14:49:03.722Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b3/ef7c3295d02e0448a71c639a36a057f46d524d057c9486291a7a3039e65c/wrapt-2.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:50972a1d974ea07725a7f6b1cec5f8759008afd030a0024843ebe7d52de47f2b", size = 81144, upload-time = "2026-05-22T14:49:05.093Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/dc/7bdf336953f99f4ceb0a584bb8870e42c8f26f93ea10c87834dad62f1668/wrapt-2.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:1c9934ea5d92957e3cd0adbc0845539dccfd62710ebe16195a8c66c53954db36", size = 79569, upload-time = "2026-05-22T14:49:06.413Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6d/6dfae80150ff1919c356d1dd528f049bcdfaae29b4d284bc957e022caef4/wrapt-2.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:17de18fc12cea55b8a9587314cb830573e37fb33b247a7515696350863714188", size = 82892, upload-time = "2026-05-22T14:49:07.925Z" },
+    { url = "https://files.pythonhosted.org/packages/82/7b/4e34766a7d7804ffce9e71befe47e9b3225dc350c49c94493c4ab39fd3a5/wrapt-2.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a9dec1aca52dddde7df94818310fa2fe79739c8f385b2014c4cb1035f5508199", size = 83333, upload-time = "2026-05-22T14:49:09.257Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/57/0b34db3e8de44ccfece62d7b337abd1631dd810f5adc5f3db571727836b5/wrapt-2.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:69f2e9244542cb34dd59c7f073445b9e54ad9f3fce8d93606c368a1b499fc413", size = 202899, upload-time = "2026-05-22T14:49:10.572Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/ac0c459f154b99d92789a6cba7ca727185b83513b986f8ec7fe2aacddcbf/wrapt-2.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d83966dc7f4f45e8b97b5933685ac2e6e67fc0e19246ea314bceb9a8970c956", size = 209986, upload-time = "2026-05-22T14:49:12.229Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/77e37ff33ad018fa81ade52c25fa327b80b56f81d734279a63614fcb4cbc/wrapt-2.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78b0aa6bfb7be8deed0ab23e7aa028cc5210c29bc2d32a04d52b50e517a7307e", size = 194893, upload-time = "2026-05-22T14:49:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9d/7ea651d1ab032fc5fa222fbec91d0f8a1397f6ae04ebb93fa7219aa921d7/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:05d5cb74d1b232ec8cfa130a8f900708699ff2491d97b8f85a4cdc5996294b85", size = 205636, upload-time = "2026-05-22T14:49:15.714Z" },
+    { url = "https://files.pythonhosted.org/packages/09/af/8e88031a701275b9085c54e64bc88c0b1cd55c77eadd400691c371cd76c4/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f6518b94edb9150452e9aba08027d4cc293433753ec1fbefb4629a21cbc74181", size = 192267, upload-time = "2026-05-22T14:49:17.283Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a8/e657ca876b06710194f243d81c4b0896ade646e244bdbec2d87c8c56a8bd/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ed55af48b3eb28f43228ca2306788892bcb629eb2b5c4876e2a3659872c2f17a", size = 198378, upload-time = "2026-05-22T14:49:18.785Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/59/822efe4ea722a3961331bfa35b7d90937790d2c20f0616de1997ccc3aebd/wrapt-2.2.1-cp314-cp314t-win32.whl", hash = "sha256:2e08688ab16525897da6589d56d0aebaf417bbe91c2d8e3b96203b1efa596e85", size = 80226, upload-time = "2026-05-22T14:49:20.264Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/2a7dc5f6abb2fca0b6e1610e120419f603650aceb4f1d3ac4cae0354e162/wrapt-2.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:fd0135d34387f5fd087d9be368ea77ea89cf2451dc1cd1c622d35021bcb3ab50", size = 83835, upload-time = "2026-05-22T14:49:21.634Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c0/782b86e28d1ceebeb74cccea12d2cd3d2ba0bd68e3dec20b1bc5873f6127/wrapt-2.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:f70db64e8266d7c45d3b735f2e08eeb434b5e03da9a479ae42b2e2e486a21a00", size = 80722, upload-time = "2026-05-22T14:49:23.59Z" },
+    { url = "https://files.pythonhosted.org/packages/53/46/29ac9daf11a86c22a8c38cd9236c62928ccae83f7ceb06bd3b0467cf9d05/wrapt-2.2.1-py3-none-any.whl", hash = "sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f", size = 61000, upload-time = "2026-05-22T14:49:41.593Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Changes

- Add new `diart.storage` module
- Add `Dataset` class to unify handling audio and rttm dirs
- Add `FilePath` class to abstract access to local and remote paths/dirs
- Replace deprecated `torchaudio` with `torchcodec`
- Add AWS S3 support for reading dataset audio and rttms, thanks to `fsspec` and `s3fs`

#286 should be merged first